### PR TITLE
Reversibility

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,6 +108,27 @@ It is then easy to see the exact differences in rendering between the systems.
 diff bgnpcgn-rus-Latn.txt bas-rus-Latn.txt
 ----
 
+You can also run some maps in reverse (warning: not all maps are made to be reversed),
+either by changing an order of character sets in a name (for bas-rus-`Cyrl-Latn`-2017-bss
+it would be bas-rus-`Latn-Cyrl`-2017-bss) or appending `-reverse` to their name:
+
+[source,sh]
+----
+interscript my_jamos.txt \
+  --system=var-kor-Hang-Hang-jamo-reverse \
+  --output=my_hangul.txt
+----
+
+You can also compose some maps, by joining their names with `|` (similar to how bash
+pipe works). For instance:
+
+[source,sh]
+----
+interscript my_file.txt \
+  --system='var-map1-Xxxx-Xxxx|var-map2-Xxxx-Xxxx' \
+  --output=my_output.txt
+----
+
 If you use Interscript from the Git repository, you would call the following command
 instead of `interscript`:
 

--- a/docs/Integration_with_Ruby_Applications.adoc
+++ b/docs/Integration_with_Ruby_Applications.adoc
@@ -70,3 +70,16 @@ output = Interscript.transliterate("bas-rus-Cyrl-Latn-2017-bss",
                                    cache,
                                    compiler: Interscript::Compiler::Ruby)
 ----
+
+=== Transliterating in reverse
+
+To reverse a given string using a map with a name of a form:
+`bas-rus-Cyrl-Latn-2017-bss`, change places for Cyrl and Latn.
+
+To reverse a given string using a map with a name of a form:
+`var-swe-Latn-Latn-2021`, append `-reverse` to its name.
+
+Please note: this only works for Ruby implementation. Other implementations
+depend on the Ruby implementation for the purpose of compilation. For those,
+you need to compile the map using the Ruby implementation, but the name has
+to be given according to the above hint.

--- a/docs/Interscript_Map_Format.adoc
+++ b/docs/Interscript_Map_Format.adoc
@@ -418,6 +418,47 @@ stage {
 When ran against a string `"abcde"`, this stage will produce an output of
 `"[a][b][c]de"`.
 
+== Reversibility
+
+Starting with Interscript 2.2 we added reversibility support. In general all
+commands, except for metadata (and tests - for now) support a `reverse_run`
+keyword. This keyword is `nil` by default, which means, that it's reversible.
+(One exception though: `sub` call, if given a `none` as `to`, defaults to
+`reverse_run: false`).
+
+`reverse_run: false` means, that the command is only ran in forward.
+`reverse_run: true`, on the other hand, means that the command is only ran in
+reverse.
+
+Example 1:
+
+[source,ruby]
+----
+stage {
+  sub "a", "b", reverse_run: true
+  sub "c", "d", reverse_run: false
+}
+----
+
+When ran in forward mode (normal run) on a string "abcde", it gives "abdde".
+When ran in reverse mode on a string "abcde", it gives "aacde".
+
+Example 2:
+
+[source,ruby]
+----
+stage {
+  parallel {
+    sub "a", "あ"
+    sub "o", "お"
+    sub "i", "い"
+  }
+}
+----
+
+When ran in forward mode (normal run) on a string "あおい", it gives "aoi".
+When ran in reverse more on a string "aoi", it gives "あおい".
+
 == Ending notes
 
 This document described everything Interscript currently supports, but it is

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -26,4 +26,6 @@ unless ENV["SKIP_JS"]
   end
 end
 
+gem 'pry'
+
 gem 'simplecov', require: false, group: :test

--- a/ruby/bin/console
+++ b/ruby/bin/console
@@ -3,12 +3,8 @@
 require "bundler/setup"
 require "interscript"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+require "interscript/utils/helpers"
+include Interscript::Utils::Helpers
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+require "pry"
+Pry.start

--- a/ruby/lib/interscript/compiler/javascript.rb
+++ b/ruby/lib/interscript/compiler/javascript.rb
@@ -103,6 +103,8 @@ class Interscript::Compiler::Javascript < Interscript::Compiler
       from = %{"#{build_regexp(r, map).gsub("/", "\\\\/")}"}
       if r.to == :upcase
         to = 'function(a){return a.toUpperCase();}'
+      elsif r.to == :downcase
+        to = 'function(a){return a.toLowerCase();}'
       else
         to = compile_item(r.to, map, :str)
       end

--- a/ruby/lib/interscript/compiler/javascript.rb
+++ b/ruby/lib/interscript/compiler/javascript.rb
@@ -53,6 +53,7 @@ class Interscript::Compiler::Javascript < Interscript::Compiler
 
   def compile_rule(r, map = @map, wrapper = false)
     c = ""
+    return c if r.reverse_run == true
     case r
     when Interscript::Node::Stage
       c += "map.stages.#{r.name} = function(s) {\n"

--- a/ruby/lib/interscript/compiler/javascript.rb
+++ b/ruby/lib/interscript/compiler/javascript.rb
@@ -76,6 +76,7 @@ class Interscript::Compiler::Javascript < Interscript::Compiler
           raise ArgumentError, "Can't parallelize rules with :not_before" if i.not_before
           raise ArgumentError, "Can't parallelize rules with :not_after" if i.not_after
 
+          next if i.reverse_run == true
           a << [compile_item(i.from, map, :par), compile_item(i.to, map, :parstr)]
         end
         ah = a.hash.abs
@@ -89,7 +90,8 @@ class Interscript::Compiler::Javascript < Interscript::Compiler
         a = []
         Interscript::Stdlib.deterministic_sort_by_max_length(r.children).each do |i|
           raise ArgumentError, "Can't parallelize #{i.class}" unless Interscript::Node::Rule::Sub === i
-
+          
+          next if i.reverse_run == true
           a << [build_regexp(i, map), compile_item(i.to, map, :parstr)]
         end
         ah = a.hash.abs

--- a/ruby/lib/interscript/compiler/ruby.rb
+++ b/ruby/lib/interscript/compiler/ruby.rb
@@ -93,6 +93,8 @@ class Interscript::Compiler::Ruby < Interscript::Compiler
       from = "/#{build_regexp(r, map).gsub("/", "\\\\/")}/"
       if r.to == :upcase
         to = '&:upcase'
+      elsif r.to == :downcase
+        to = '&:downcase'
       else
         to = compile_item(r.to, map, :str)
       end

--- a/ruby/lib/interscript/compiler/ruby.rb
+++ b/ruby/lib/interscript/compiler/ruby.rb
@@ -42,6 +42,7 @@ class Interscript::Compiler::Ruby < Interscript::Compiler
 
   def compile_rule(r, map = @map, wrapper = false)
     c = ""
+    return c if r.reverse_run == true
     case r
     when Interscript::Node::Stage
       c += "Interscript::Maps.add_map_stage \"#{@map.name}\", #{r.name.inspect} do |s|\n"

--- a/ruby/lib/interscript/compiler/ruby.rb
+++ b/ruby/lib/interscript/compiler/ruby.rb
@@ -66,6 +66,7 @@ class Interscript::Compiler::Ruby < Interscript::Compiler
           raise ArgumentError, "Can't parallelize rules with :not_before" if i.not_before
           raise ArgumentError, "Can't parallelize rules with :not_after" if i.not_after
 
+          next if i.reverse_run == true
           a << [compile_item(i.from, map, :par), compile_item(i.to, map, :parstr)]
         end
         ah = a.hash.abs
@@ -80,6 +81,7 @@ class Interscript::Compiler::Ruby < Interscript::Compiler
         Interscript::Stdlib.deterministic_sort_by_max_length(r.children).each do |i|
           raise ArgumentError, "Can't parallelize #{i.class}" unless Interscript::Node::Rule::Sub === i
 
+          next if i.reverse_run == true
           a << [build_regexp(i, map), compile_item(i.to, map, :parstr)]
         end
         ah = a.hash.abs

--- a/ruby/lib/interscript/dsl.rb
+++ b/ruby/lib/interscript/dsl.rb
@@ -6,8 +6,20 @@ module Interscript::DSL
     # map name aliases? here may be a place to wrap it
 
     return @cache[map_name] if @cache[map_name]
-    path = Interscript.locate(map_name)
+
+    reverse = false
+    path = begin
+      Interscript.locate(map_name)
+    rescue Interscript::MapNotFoundError => e
+      begin
+        reverse = map_name
+        Interscript.locate(Interscript::Node::Document.reverse_name(map_name))
+      rescue Interscript::MapNotFoundError
+        raise e
+      end
+    end
     library = path.end_with?(".iml")
+
     map_name = File.basename(path, ".imp")
     map_name = File.basename(map_name, ".iml")
 
@@ -54,6 +66,12 @@ module Interscript::DSL
     obj.node.metadata = md.node
 
     @cache[map_name] = obj.node
+
+    if reverse
+      @cache[reverse] = @cache[map_name].reverse
+    else
+      @cache[map_name]
+    end
   end
 end
 

--- a/ruby/lib/interscript/dsl/group.rb
+++ b/ruby/lib/interscript/dsl/group.rb
@@ -8,16 +8,16 @@ class Interscript::DSL::Group
     self.instance_exec(&block)
   end
 
-  def run(stage)
+  def run(stage, **kwargs)
     if stage.class != Interscript::Node::Item::Stage
       raise TypeError, "I::Node::Item::Stage expected, got #{stage.class}"
     end
-    @node.children << Interscript::Node::Rule::Run.new(stage)
+    @node.children << Interscript::Node::Rule::Run.new(stage, **kwargs)
   end
 
   def sub(from, to, **kwargs, &block)
-    puts "sub(#{from.inspect},#{to}, kargs = #{
-      kargs.inspect
+    puts "sub(#{from.inspect},#{to}, kwargs = #{
+      kwargs.inspect
     }) from #{self.inspect}" if $DEBUG
 
     rule = Interscript::Node::Rule::Sub.new(from, to, **kwargs)
@@ -35,9 +35,9 @@ class Interscript::DSL::Group
     end
   end
 
-  def parallel(&block)
+  def parallel(**kwargs, &block)
     puts "parallel(#{chars.inspect}) from #{self.inspect}" if $DEBUG
-    group = Interscript::DSL::Group::Parallel.new(&block)
+    group = Interscript::DSL::Group::Parallel.new(**kwargs, &block)
     @node.children << group.node
   end
 end

--- a/ruby/lib/interscript/dsl/group.rb
+++ b/ruby/lib/interscript/dsl/group.rb
@@ -25,6 +25,7 @@ class Interscript::DSL::Group
   end
 
   def upcase; :upcase; end
+  def downcase; :downcase; end
 
   Interscript::Stdlib.available_functions.each do |fun|
     define_method fun do |**kwargs|

--- a/ruby/lib/interscript/dsl/group/parallel.rb
+++ b/ruby/lib/interscript/dsl/group/parallel.rb
@@ -1,6 +1,6 @@
 class Interscript::DSL::Group::Parallel < Interscript::DSL::Group
-  def initialize(&block)
-    @node = Interscript::Node::Group::Parallel.new
+  def initialize(reverse_run: nil, &block)
+    @node = Interscript::Node::Group::Parallel.new(reverse_run: reverse_run)
     self.instance_exec(&block)
   end
 end

--- a/ruby/lib/interscript/interpreter.rb
+++ b/ruby/lib/interscript/interpreter.rb
@@ -130,6 +130,8 @@ class Interscript::Interpreter < Interscript::Compiler
       when Interscript::Node::Rule::Sub
         if r.to == :upcase
           @str = @str.gsub(Regexp.new(build_regexp(r)), &:upcase)
+        elsif r.to == :downcase
+          @str = @str.gsub(Regexp.new(build_regexp(r)), &:downcase)
         else
           @str = @str.gsub(Regexp.new(build_regexp(r)), build_item(r.to, :str))
         end

--- a/ruby/lib/interscript/interpreter.rb
+++ b/ruby/lib/interscript/interpreter.rb
@@ -76,6 +76,7 @@ class Interscript::Interpreter < Interscript::Compiler
     end
 
     def execute_rule r
+      return if r.reverse_run == true
       case r
       when Interscript::Node::Group::Parallel
         if r.cached_tree

--- a/ruby/lib/interscript/interpreter.rb
+++ b/ruby/lib/interscript/interpreter.rb
@@ -97,6 +97,7 @@ class Interscript::Interpreter < Interscript::Compiler
               raise ArgumentError, "Can't parallelize rules with :after" if i.after
               raise ArgumentError, "Can't parallelize rules with :not_before" if i.not_before
               raise ArgumentError, "Can't parallelize rules with :not_after" if i.not_after
+              next if i.reverse_run == true
               subs_array << [build_item(i.from, :par), build_item(i.to, :parstr)]
             end
             tree = Interscript::Stdlib.parallel_replace_compile_tree(subs_array) #.sort_by{|k,v| -k.length})
@@ -109,7 +110,7 @@ class Interscript::Interpreter < Interscript::Compiler
             subs_array = []
             Interscript::Stdlib.deterministic_sort_by_max_length(r.children).each do |i|  # rule.from.max_length gives somewhat better test results, why is that
               raise ArgumentError, "Can't parallelize #{i.class}" unless Interscript::Node::Rule::Sub === i
-
+              next if i.reverse_run == true
               subs_array << [build_regexp(i), build_item(i.to, :parstr)]
             end
             r.subs_regexp = Interscript::Stdlib.parallel_regexp_compile(subs_array)

--- a/ruby/lib/interscript/node.rb
+++ b/ruby/lib/interscript/node.rb
@@ -4,6 +4,10 @@ class Interscript::Node
     raise NotImplementedError, "You can't construct a Node directly"
   end
 
+  def ==(other)
+    self.class == other.class
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :question => "is something missing?"

--- a/ruby/lib/interscript/node/alias_def.rb
+++ b/ruby/lib/interscript/node/alias_def.rb
@@ -7,6 +7,12 @@ class Interscript::Node::AliasDef < Interscript::Node
     @data = data
   end
 
+  def ==(other)
+    super &&
+    self.name == other.name &&
+    self.data == other.data
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :name => @name,

--- a/ruby/lib/interscript/node/dependency.rb
+++ b/ruby/lib/interscript/node/dependency.rb
@@ -4,6 +4,15 @@ class Interscript::Node::Dependency < Interscript::Node
   def initialize
   end
 
+  def reverse
+    rdep = self.class.new
+    rdep.name = name
+    rdep.full_name = Interscript::Node::Document.reverse_name(full_name)
+    rdep.import = import
+    rdep.document = document&.reverse
+    rdep
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :name => @name,

--- a/ruby/lib/interscript/node/dependency.rb
+++ b/ruby/lib/interscript/node/dependency.rb
@@ -13,6 +13,13 @@ class Interscript::Node::Dependency < Interscript::Node
     rdep
   end
 
+  def ==(other)
+    super &&
+    self.full_name == other.full_name &&
+    self.import == other.import &&
+    self.name == other.name
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :name => @name,

--- a/ruby/lib/interscript/node/document.rb
+++ b/ruby/lib/interscript/node/document.rb
@@ -34,6 +34,31 @@ class Interscript::Node::Document
     end
   end
 
+  def reverse
+    @reverse ||= self.class.new.tap do |rdoc|
+      rdoc.name = self.class.reverse_name(name)
+      rdoc.metadata = metadata&.reverse
+      rdoc.tests = tests&.reverse
+      rdoc.dependencies = dependencies.map(&:reverse)
+      rdoc.stages = stages.transform_values(&:reverse)
+      rdoc.dep_aliases = dep_aliases.transform_values(&:reverse)
+      rdoc.aliases = aliases
+    end
+  end
+
+  def self.reverse_name(name)
+    newname = (name || "noname").split("-")
+    newname[2], newname[3] = newname[3], newname[2] if newname.length >= 4
+    newname = newname.join("-")
+    if newname == name
+      newname.gsub!("-reverse", "")
+    end
+    if newname == name
+      newname += "-reverse"
+    end
+    newname
+  end
+
   def to_hash
     { :class => self.class.to_s, :metadata => @metadata&.to_hash,
       :tests => @tests&.to_hash,

--- a/ruby/lib/interscript/node/document.rb
+++ b/ruby/lib/interscript/node/document.rb
@@ -59,6 +59,14 @@ class Interscript::Node::Document
     newname
   end
 
+  def ==(other)
+    self.class == other.class &&
+    self.metadata == other.metadata &&
+    self.tests == other.tests &&
+    self.stages == other.stages &&
+    self.aliases == other.aliases
+  end
+
   def to_hash
     { :class => self.class.to_s, :metadata => @metadata&.to_hash,
       :tests => @tests&.to_hash,

--- a/ruby/lib/interscript/node/group.rb
+++ b/ruby/lib/interscript/node/group.rb
@@ -1,7 +1,8 @@
 class Interscript::Node::Group < Interscript::Node
-  attr_accessor :children
+  attr_accessor :children, :reverse_run
 
-  def initialize
+  def initialize(reverse_run: nil)
+    @reverse_run = reverse_run
     @children = []
   end
 
@@ -18,6 +19,12 @@ class Interscript::Node::Group < Interscript::Node
     @children = children_new
     #@children[source], @children[target] = @children[target], @children[source]
     self
+  end
+
+  def reverse
+    self.class.new(reverse_run: reverse_run.nil? ? nil : !reverse_run).tap do |r|
+      r.children = self.children.reverse.map(&:reverse)
+    end
   end
 
   def to_hash

--- a/ruby/lib/interscript/node/group.rb
+++ b/ruby/lib/interscript/node/group.rb
@@ -32,6 +32,10 @@ class Interscript::Node::Group < Interscript::Node
       :children => @children.map{|x| x.to_hash} }
   end
 
+  def ==(other)
+    super && self.children == other.children && self.reverse_run == other.reverse_run
+  end
+
   def inspect
     @children.map(&:inspect).join("\n").gsub(/^/, "  ")
   end

--- a/ruby/lib/interscript/node/item.rb
+++ b/ruby/lib/interscript/node/item.rb
@@ -36,6 +36,10 @@ class Interscript::Node::Item < Interscript::Node
       :item => self.item }
   end
 
+  def ==(other)
+    super
+  end
+
   def self.try_convert(i)
     i = Interscript::Node::Item::String.new(i) if i.class == ::String
     raise TypeError, "Wrong type #{i.class}, expected I::Node::Item" unless Interscript::Node::Item === i

--- a/ruby/lib/interscript/node/item/alias.rb
+++ b/ruby/lib/interscript/node/item/alias.rb
@@ -10,6 +10,10 @@ class Interscript::Node::Item::Alias < Interscript::Node::Item
     !map && Interscript::Stdlib::ALIASES.has_key?(name)
   end
 
+  def boundary_like?
+    Interscript::Stdlib.boundary_like_alias?(name)
+  end
+
   def max_length
     if stdlib?
       ([:none].include? name) ? 0 : 1
@@ -20,9 +24,8 @@ class Interscript::Node::Item::Alias < Interscript::Node::Item
   end
 
   # Not implemented properly
-  def downcase
-    self
-  end
+  def downcase; self; end
+  def upcase; self; end
 
   def first_string
     self

--- a/ruby/lib/interscript/node/item/alias.rb
+++ b/ruby/lib/interscript/node/item/alias.rb
@@ -19,6 +19,11 @@ class Interscript::Node::Item::Alias < Interscript::Node::Item
     end
   end
 
+  # Not implemented properly
+  def downcase
+    self
+  end
+
   def first_string
     self
   end

--- a/ruby/lib/interscript/node/item/alias.rb
+++ b/ruby/lib/interscript/node/item/alias.rb
@@ -40,6 +40,10 @@ class Interscript::Node::Item::Alias < Interscript::Node::Item
     }
   end
 
+  def ==(other)
+    super && self.name == other.name && self.map == other.map
+  end
+
   def inspect
     if map
       "map.#{map}.#{name}"

--- a/ruby/lib/interscript/node/item/any.rb
+++ b/ruby/lib/interscript/node/item/any.rb
@@ -25,9 +25,8 @@ class Interscript::Node::Item::Any < Interscript::Node::Item
     end
   end
 
-  def downcase
-    self.class.new(self.data.map(&:downcase))
-  end
+  def downcase; self.class.new(self.data.map(&:downcase)); end
+  def upcase; self.class.new(self.data.map(&:upcase)); end
 
   def first_string
     case @value

--- a/ruby/lib/interscript/node/item/any.rb
+++ b/ruby/lib/interscript/node/item/any.rb
@@ -25,6 +25,10 @@ class Interscript::Node::Item::Any < Interscript::Node::Item
     end
   end
 
+  def downcase
+    self.class.new(self.data.map(&:downcase))
+  end
+
   def first_string
     case @value
     when Array

--- a/ruby/lib/interscript/node/item/any.rb
+++ b/ruby/lib/interscript/node/item/any.rb
@@ -73,6 +73,10 @@ class Interscript::Node::Item::Any < Interscript::Node::Item
     hash
   end
 
+  def ==(other)
+    super && self.data == other.data
+  end
+
   def inspect
     "any(#{value.inspect})"
   end

--- a/ruby/lib/interscript/node/item/capture.rb
+++ b/ruby/lib/interscript/node/item/capture.rb
@@ -15,6 +15,9 @@ class Interscript::Node::Item::CaptureGroup < Interscript::Node::Item
     data.nth_string
   end
 
+  def downcase; self.dup.tap { |i| i.data = i.data.downcase }; end
+  def upcase; self.dup.tap { |i| i.data = i.data.upcase }; end
+
   def to_hash
     { :class => self.class.to_s,
       :data => self.data.to_hash }

--- a/ruby/lib/interscript/node/item/capture.rb
+++ b/ruby/lib/interscript/node/item/capture.rb
@@ -23,6 +23,10 @@ class Interscript::Node::Item::CaptureGroup < Interscript::Node::Item
       :data => self.data.to_hash }
   end
 
+  def ==(other)
+    super && self.data == other.data
+  end
+
   def inspect
     "capture(#{@data.inspect})"
   end
@@ -45,6 +49,10 @@ class Interscript::Node::Item::CaptureRef < Interscript::Node::Item
   def to_hash
     { :class => self.class.to_s,
       :id => self.id }
+  end
+
+  def ==(other)
+    super && self.id == other.id
   end
 
   def inspect

--- a/ruby/lib/interscript/node/item/group.rb
+++ b/ruby/lib/interscript/node/item/group.rb
@@ -10,10 +10,34 @@ class Interscript::Node::Item::Group < Interscript::Node::Item
   def +(item)
     item = Interscript::Node::Item.try_convert(item)
     out = self.dup
-    out.children << item
+    if Interscript::Node::Item::Group === item
+      out.children += item.children
+    else
+      out.children << item
+    end
     out.verify!
     out
   end
+
+  def compact
+    out = self.dup do |n|
+      n.children = n.children.reject do |i|
+        (Interscript::Node::Alias === i && i.name == :none) ||
+        (Interscript::Node::String === i && i.data == "")
+      end
+    end
+
+    if out.children.count == 0
+      Interscript::Node::Alias.new(:none)
+    elsif out.children.count == 1
+      out.children.first
+    else
+      out
+    end
+  end
+
+  def downcase; self.dup.tap { |i| i.children = i.children.map(&:downcase) }; end
+  def upcase; self.dup.tap { |i| i.children = i.children.map(&:upcase) }; end
 
   # Verify if a group is valid
   def verify!

--- a/ruby/lib/interscript/node/item/group.rb
+++ b/ruby/lib/interscript/node/item/group.rb
@@ -69,6 +69,10 @@ class Interscript::Node::Item::Group < Interscript::Node::Item
       :children => self.children.map{|x| x.to_hash} }
   end
 
+  def ==(other)
+    super && self.children == other.children
+  end
+
   def inspect
     @children.map(&:inspect).join("+")
   end

--- a/ruby/lib/interscript/node/item/repeat.rb
+++ b/ruby/lib/interscript/node/item/repeat.rb
@@ -22,6 +22,10 @@ class Interscript::Node::Item::Repeat < Interscript::Node::Item
       :data => self.data.to_hash }
   end
 
+  def ==(other)
+    super && self.data == other.data
+  end
+
   def inspect
     str = case self
     when Interscript::Node::Item::Maybe

--- a/ruby/lib/interscript/node/item/stage.rb
+++ b/ruby/lib/interscript/node/item/stage.rb
@@ -13,6 +13,10 @@ class Interscript::Node::Item::Stage < Interscript::Node::Item
     }
   end
 
+  def ==(other)
+    super && self.name == other.name && self.map == other.map
+  end
+
   def inspect
     if map
       "map.#{@map}.stage.#{@name}"

--- a/ruby/lib/interscript/node/item/string.rb
+++ b/ruby/lib/interscript/node/item/string.rb
@@ -17,6 +17,10 @@ class Interscript::Node::Item::String < Interscript::Node::Item
     self.data
   end
 
+  def downcase
+    self.class.new(data.downcase)
+  end
+
   alias nth_string first_string
 
   def + other

--- a/ruby/lib/interscript/node/item/string.rb
+++ b/ruby/lib/interscript/node/item/string.rb
@@ -17,9 +17,8 @@ class Interscript::Node::Item::String < Interscript::Node::Item
     self.data
   end
 
-  def downcase
-    self.class.new(data.downcase)
-  end
+  def downcase; self.dup.tap { |i| i.data = i.data.downcase }; end
+  def upcase; self.dup.tap { |i| i.data = i.data.upcase }; end
 
   alias nth_string first_string
 

--- a/ruby/lib/interscript/node/item/string.rb
+++ b/ruby/lib/interscript/node/item/string.rb
@@ -36,6 +36,10 @@ class Interscript::Node::Item::String < Interscript::Node::Item
     end
   end
 
+  def ==(other)
+    super && self.data == other.data
+  end
+
   def inspect
     @data.inspect
   end

--- a/ruby/lib/interscript/node/metadata.rb
+++ b/ruby/lib/interscript/node/metadata.rb
@@ -11,6 +11,12 @@ class Interscript::Node::MetaData < Interscript::Node
     @data[k]
   end
 
+  def reverse
+    self.class.new(data: data.dup).tap do |rmd|
+      rmd[:source_script], rmd[:destination_script] = rmd[:destination_script], rmd[:source_script]
+    end
+  end
+
   def to_hash
     {:class => self.class.to_s,
       :data => @data}

--- a/ruby/lib/interscript/node/metadata.rb
+++ b/ruby/lib/interscript/node/metadata.rb
@@ -12,9 +12,13 @@ class Interscript::Node::MetaData < Interscript::Node
   end
 
   def reverse
-    self.class.new(data: data.dup).tap do |rmd|
+    self.class.new(data.dup, **{}).tap do |rmd|
       rmd[:source_script], rmd[:destination_script] = rmd[:destination_script], rmd[:source_script]
     end
+  end
+
+  def ==(other)
+    super && self.data == other.data
   end
 
   def to_hash

--- a/ruby/lib/interscript/node/rule.rb
+++ b/ruby/lib/interscript/node/rule.rb
@@ -1,4 +1,7 @@
 class Interscript::Node::Rule < Interscript::Node
+  def ==(other)
+    super && self.reverse_run == other.reverse_run
+  end
 end
 
 require "interscript/node/rule/sub"

--- a/ruby/lib/interscript/node/rule/funcall.rb
+++ b/ruby/lib/interscript/node/rule/funcall.rb
@@ -1,7 +1,8 @@
 class Interscript::Node::Rule::Funcall < Interscript::Node::Rule
-  attr_accessor :name, :kwargs
-  def initialize name, **kwargs
+  attr_accessor :name, :kwargs, :reverse_run
+  def initialize name, reverse_run: nil, **kwargs
     @name = name
+    @reverse_run = reverse_run
     @kwargs = kwargs
   end
 
@@ -10,6 +11,11 @@ class Interscript::Node::Rule::Funcall < Interscript::Node::Rule
       :name => self.name,
       :kwargs => self.kwargs
     }
+  end
+
+  def reverse
+    self.class.new(Interscript::Stdlib.reverse_function[@name.to_sym],
+      reverse_run: reverse_run.nil? ? nil : !reverse_run, **kwargs)
   end
 
   def inspect

--- a/ruby/lib/interscript/node/rule/funcall.rb
+++ b/ruby/lib/interscript/node/rule/funcall.rb
@@ -18,6 +18,10 @@ class Interscript::Node::Rule::Funcall < Interscript::Node::Rule
       reverse_run: reverse_run.nil? ? nil : !reverse_run, **kwargs)
   end
 
+  def ==
+    super && self.name == other.name && self.kwargs == other.kwargs
+  end
+
   def inspect
     "#{@name} #{kwargs.inspect[1..-2]}"
   end

--- a/ruby/lib/interscript/node/rule/run.rb
+++ b/ruby/lib/interscript/node/rule/run.rb
@@ -1,7 +1,8 @@
 class Interscript::Node::Rule::Run < Interscript::Node::Rule
-  attr_accessor :stage
-  def initialize stage
+  attr_accessor :stage, :reverse_run
+  def initialize stage, reverse_run: nil
     @stage = stage
+    @reverse_run = reverse_run
   end
 
   def to_hash
@@ -9,7 +10,15 @@ class Interscript::Node::Rule::Run < Interscript::Node::Rule
       :stage => self.stage.to_hash }
   end
 
+  def reverse
+    Interscript::Node::Rule::Run.new(stage,
+      reverse_run: reverse_run.nil? ? nil : !reverse_run
+    )
+  end
+
   def inspect
-    "run #{@stage.inspect}"
+    out = "run #{@stage.inspect}"
+    out += ", reverse_run: #{@reverse_run.inspect}" unless reverse_run.nil?
+    out
   end
 end

--- a/ruby/lib/interscript/node/rule/run.rb
+++ b/ruby/lib/interscript/node/rule/run.rb
@@ -16,6 +16,10 @@ class Interscript::Node::Rule::Run < Interscript::Node::Rule
     )
   end
 
+  def ==(other)
+    super && self.stage == other.stage
+  end
+
   def inspect
     out = "run #{@stage.inspect}"
     out += ", reverse_run: #{@reverse_run.inspect}" unless reverse_run.nil?

--- a/ruby/lib/interscript/node/rule/sub.rb
+++ b/ruby/lib/interscript/node/rule/sub.rb
@@ -8,12 +8,12 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
   def initialize (from, to,
                   before: nil, not_before: nil,
                   after: nil, not_after: nil,
-                  reverse_before: nil, reverse_not_before: nil,
-                  reverse_after: nil, reverse_not_after: nil,
                   priority: nil, reverse_run: nil)
     self.from = Interscript::Node::Item.try_convert from
     if to == :upcase
       self.to = :upcase
+    elsif to == :downcase
+      self.to = :downcase
     else
       self.to = Interscript::Node::Item.try_convert to
     end
@@ -29,11 +29,6 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     self.after = Interscript::Node::Item.try_convert(after) if after
     self.not_before = Interscript::Node::Item.try_convert(not_before) if not_before
     self.not_after = Interscript::Node::Item.try_convert(not_after) if not_after
-
-    self.reverse_before = Interscript::Node::Item.try_convert(reverse_before) if reverse_before
-    self.reverse_after = Interscript::Node::Item.try_convert(reverse_after) if reverse_after
-    self.reverse_not_before = Interscript::Node::Item.try_convert(reverse_not_before) if reverse_not_before
-    self.reverse_not_after = Interscript::Node::Item.try_convert(reverse_not_after) if reverse_not_after
   end
 
   def max_length
@@ -51,16 +46,12 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     puts params.inspect if $DEBUG
     hash = { :class => self.class.to_s,
       :from => self.from.to_hash,
-      :to => Symbol === self.to ? self.to : self.to.to_hash
+      :to => Symbol === self.to ? self.to : self.to.to_hash,
       :reverse_run => self.reverse_run,
       :before => self.before&.to_hash,
       :not_before => self.not_before&.to_hash,
       :after => self.after&.to_hash,
       :not_after => self.not_after&.to_hash,
-      :reverse_before => self.reverse_before&.to_hash,
-      :reverse_not_before => self.reverse_not_before&.to_hash,
-      :reverse_after => self.reverse_after&.to_hash,
-      :reverse_not_after => self.reverse_not_after&.to_hash,
       :priority => self.priority
     }
 
@@ -75,17 +66,17 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
 
   def reverse
     if to == :upcase
-      xfrom = :upcase
-      xto = from.downcase
+      xfrom = from.downcase
+      xto = :downcase
+    elsif to == :downcase
+      xfrom = from.upcase
+      xto = :upcase
     else
-      xfrom, xto = from, to
+      xto, xfrom = reverse_transfer(from, to)
     end
-    Interscript::Node::Rule::Sub.new(xto, xfrom,
-      before: reverse_before, after: reverse_after,
-      not_before: reverse_not_before, not_after: reverse_not_after,
-
-      reverse_before: before, reverse_after: after,
-      reverse_not_before: not_before, reverse_not_after: not_after,
+    Interscript::Node::Rule::Sub.new(xfrom, xto,
+      before: before, after: after,
+      not_before: not_before, not_after: not_after,
 
       reverse_run: reverse_run.nil? ? nil : !reverse_run,
 
@@ -93,12 +84,108 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     )
   end
 
+  # Attempt to transfer some references to boundary/line_begin around.
+  # Those in general should go into before/after clauses, but for now
+  # let's try to get the best compatibility possible. Also, CaptureGroup,
+  # CaptureRef need to be shifted around
+  def reverse_transfer from, to
+    # This part is about moving initial and final boundary like aliases
+    case from
+    when Interscript::Node::Item::Group
+      first = from.children.first
+      last = from.children.last
+
+      if Interscript::Node::Item::Alias === first && first.boundary_like?
+        out = Interscript::Node::Item::Group.new + first + to
+        to = out.compact
+
+        from = from.dup.tap do |i|
+          i.children = i.children[1..-1]
+        end.compact
+      end
+
+      if Interscript::Node::Item::Alias === last && last.boundary_like?
+        out = Interscript::Node::Item::Group.new + to + last
+        to = out.compact
+
+        from = from.dup.tap do |i|
+          i.children = i.children[0..-2]
+        end.compact
+      end
+    when Interscript::Node::Item::Alias
+      if from.boundary_like?
+        to = if from.name.to_s.end_with? "_end"
+          Interscript::Node::Item::Group.new + to + from
+        else
+          Interscript::Node::Item::Group.new + from + to
+        end
+        from = Interscript::Node::Item::Alias.new(:none)
+      end
+    end
+
+    # This part is about moving backreferences
+    state = {left:[], right:[]}
+
+    from  = reverse_transfer_visit(from, :from, state)
+    to    = reverse_transfer_visit(to,   :to,   state)
+
+    [from, to]
+  end
+
+  private def reverse_transfer_visit(node, type, state)
+    node = Interscript::Node::Item.try_convert(node)
+
+    case node
+    when Interscript::Node::Item::Alias
+      if node.name == :kor_maybedash
+        state[:left] << node
+        Interscript::Node::Item::CaptureRef.new(state[:left].length)
+      else
+        node
+      end
+    when Interscript::Node::Item::String
+      node
+    when Interscript::Node::Item::Any
+      if Array === node.value
+        node.dup.tap do |i|
+          i.value = i.value.map { |c| reverse_transfer_visit(c, type, state) }
+        end
+      else
+        node
+      end
+    when Interscript::Node::Item::Group
+      node.dup.tap do |i|
+        i.children = i.children.map { |c| reverse_transfer_visit(c, type, state) }
+      end
+    when Interscript::Node::Item::Repeat
+      node.dup.tap do |i|
+        i.data = reverse_transfer_visit(i.data, type, state)
+      end
+    when Interscript::Node::Item::CaptureRef
+      if type == :from
+        node
+      elsif state[:right][node.id]
+        node
+      else
+        state[:right][node.id] = true
+        state[:left][node.id - 1] or raise "Capture count doesn't match"
+      end
+    when Interscript::Node::Item::CaptureGroup
+      state[:left] << node
+      out = Interscript::Node::Item::CaptureRef.new(state[:left].length)
+      reverse_transfer_visit(node.data, type, state) # Visit but don't care
+      out
+    else
+      raise "Type #{node.class} unhandled!"
+    end
+  end
+
   def inspect
     out = "sub "
     params = []
     params << @from.inspect
-    if @to == :upcase
-      params << "upcase"
+    if Symbol === @to
+      params << @to.to_s
     else
       params << @to.inspect
     end
@@ -108,11 +195,6 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     params << "after: #{@after.inspect}" if @after
     params << "not_before: #{@not_before.inspect}" if @not_before
     params << "not_after: #{@not_after.inspect}" if @not_after
-
-    params << "reverse_before: #{@reverse_before.inspect}" if @reverse_before
-    params << "reverse_after: #{@reverse_after.inspect}" if @reverse_after
-    params << "reverse_not_before: #{@reverse_not_before.inspect}" if @reverse_not_before
-    params << "reverse_not_after: #{@reverse_not_after.inspect}" if @reverse_not_after
 
     params << "priority: #{@priority.inspect}" if @priority
     out << params.join(", ")

--- a/ruby/lib/interscript/node/rule/sub.rb
+++ b/ruby/lib/interscript/node/rule/sub.rb
@@ -1,9 +1,16 @@
 class Interscript::Node::Rule::Sub < Interscript::Node::Rule
   attr_accessor :from, :to
   attr_accessor :before, :not_before, :after, :not_after
+  attr_accessor :reverse_before, :reverse_not_before, :reverse_after, :reverse_not_after
+  attr_accessor :reverse_run
   attr_accessor :priority
 
-  def initialize from, to, before: nil, not_before: nil, after: nil, not_after: nil, priority: nil
+  def initialize (from, to,
+                  before: nil, not_before: nil,
+                  after: nil, not_after: nil,
+                  reverse_before: nil, reverse_not_before: nil,
+                  reverse_after: nil, reverse_not_after: nil,
+                  priority: nil, reverse_run: nil)
     self.from = Interscript::Node::Item.try_convert from
     if to == :upcase
       self.to = :upcase
@@ -16,10 +23,17 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     #raise TypeError, "Can't supply both before and not_before" if before && not_before
     #raise TypeError, "Can't supply both after and not_after" if after && not_after
 
+    self.reverse_run = reverse_run
+
     self.before = Interscript::Node::Item.try_convert(before) if before
     self.after = Interscript::Node::Item.try_convert(after) if after
     self.not_before = Interscript::Node::Item.try_convert(not_before) if not_before
     self.not_after = Interscript::Node::Item.try_convert(not_after) if not_after
+
+    self.reverse_before = Interscript::Node::Item.try_convert(reverse_before) if reverse_before
+    self.reverse_after = Interscript::Node::Item.try_convert(reverse_after) if reverse_after
+    self.reverse_not_before = Interscript::Node::Item.try_convert(reverse_not_before) if reverse_not_before
+    self.reverse_not_after = Interscript::Node::Item.try_convert(reverse_not_after) if reverse_not_after
   end
 
   def max_length
@@ -38,6 +52,16 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     hash = { :class => self.class.to_s,
       :from => self.from.to_hash,
       :to => Symbol === self.to ? self.to : self.to.to_hash
+      :reverse_run => self.reverse_run,
+      :before => self.before&.to_hash,
+      :not_before => self.not_before&.to_hash,
+      :after => self.after&.to_hash,
+      :not_after => self.not_after&.to_hash,
+      :reverse_before => self.reverse_before&.to_hash,
+      :reverse_not_before => self.reverse_not_before&.to_hash,
+      :reverse_after => self.reverse_after&.to_hash,
+      :reverse_not_after => self.reverse_not_after&.to_hash,
+      :priority => self.priority
     }
 
     hash[:before] = self.before&.to_hash if self.before
@@ -49,6 +73,26 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     hash
   end
 
+  def reverse
+    if to == :upcase
+      xfrom = :upcase
+      xto = from.downcase
+    else
+      xfrom, xto = from, to
+    end
+    Interscript::Node::Rule::Sub.new(xto, xfrom,
+      before: reverse_before, after: reverse_after,
+      not_before: reverse_not_before, not_after: reverse_not_after,
+
+      reverse_before: before, reverse_after: after,
+      reverse_not_before: not_before, reverse_not_after: not_after,
+
+      reverse_run: reverse_run.nil? ? nil : !reverse_run,
+
+      priority: priority
+    )
+  end
+
   def inspect
     out = "sub "
     params = []
@@ -58,10 +102,18 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     else
       params << @to.inspect
     end
+    params << "reverse_run: #{@reverse_run.inspect}" unless @reverse_run.nil?
+
     params << "before: #{@before.inspect}" if @before
     params << "after: #{@after.inspect}" if @after
     params << "not_before: #{@not_before.inspect}" if @not_before
     params << "not_after: #{@not_after.inspect}" if @not_after
+
+    params << "reverse_before: #{@reverse_before.inspect}" if @reverse_before
+    params << "reverse_after: #{@reverse_after.inspect}" if @reverse_after
+    params << "reverse_not_before: #{@reverse_not_before.inspect}" if @reverse_not_before
+    params << "reverse_not_after: #{@reverse_not_after.inspect}" if @reverse_not_after
+
     params << "priority: #{@priority.inspect}" if @priority
     out << params.join(", ")
   end

--- a/ruby/lib/interscript/node/rule/sub.rb
+++ b/ruby/lib/interscript/node/rule/sub.rb
@@ -196,6 +196,17 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
     end
   end
 
+  def ==(other)
+    super &&
+    self.from == other.from &&
+    self.to == other.to &&
+    self.before == other.before &&
+    self.after == other.after &&
+    self.not_before == other.not_before &&
+    self.not_after == other.not_after &&
+    self.priority == other.priority
+  end
+
   def inspect
     out = "sub "
     params = []

--- a/ruby/lib/interscript/node/stage.rb
+++ b/ruby/lib/interscript/node/stage.rb
@@ -1,15 +1,27 @@
 class Interscript::Node::Stage < Interscript::Node::Group::Sequential
   attr_accessor :name, :doc_name
 
-  def initialize name = :main
+  def initialize(name = :main, reverse_run: nil, doc_name: nil)
     @name = name
-    super()
+    @doc_name = doc_name
+    super(reverse_run: reverse_run)
   end
 
   def to_hash
     { :class => self.class.to_s,
       :name => name,
       :children => @children.map{|x| x.to_hash} }
+  end
+
+  def reverse
+    @reverse ||= begin
+      self.class.new(name,
+        doc_name: Interscript::Node::Document.reverse_name(doc_name),
+        reverse_run: reverse_run.nil? ? nil : !reverse_run
+      ).tap do |r|
+        r.children = self.children.reverse.map(&:reverse)
+      end
+    end
   end
 
   def inspect

--- a/ruby/lib/interscript/node/stage.rb
+++ b/ruby/lib/interscript/node/stage.rb
@@ -24,6 +24,12 @@ class Interscript::Node::Stage < Interscript::Node::Group::Sequential
     end
   end
 
+  def ==(other)
+    super &&
+    self.name == other.name &&
+    self.reverse_run == other.reverse_run
+  end
+
   def inspect
     name = "(#{@name})" if @name != :main
     "stage#{name} {\n#{super}\n}"

--- a/ruby/lib/interscript/node/tests.rb
+++ b/ruby/lib/interscript/node/tests.rb
@@ -8,6 +8,10 @@ class Interscript::Node::Tests < Interscript::Node
     @data << pair
   end
 
+  def reverse
+    self.class.new(data.map(&:reverse))
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :data => @data }

--- a/ruby/lib/interscript/node/tests.rb
+++ b/ruby/lib/interscript/node/tests.rb
@@ -12,6 +12,10 @@ class Interscript::Node::Tests < Interscript::Node
     self.class.new(data.map(&:reverse))
   end
 
+  def ==(other)
+    super && self.data == other.data
+  end
+
   def to_hash
     { :class => self.class.to_s,
       :data => @data }

--- a/ruby/lib/interscript/stdlib.rb
+++ b/ruby/lib/interscript/stdlib.rb
@@ -22,6 +22,10 @@ class Interscript::Stdlib
     ! %i[none space].include?(a)
   end
 
+  def self.boundary_like_alias?(a)
+    %i[line_start line_end string_start string_end boundary non_word_boundary].include?(a)
+  end
+
   @treecache = {}
 
   def self.parallel_regexp_compile(subs_hash)

--- a/ruby/lib/interscript/stdlib.rb
+++ b/ruby/lib/interscript/stdlib.rb
@@ -167,7 +167,20 @@ class Interscript::Stdlib
   end
 
   def self.available_functions
-    %i[title_case downcase compose decompose separate secryst]
+    %i[title_case downcase compose decompose separate unseparate secryst]
+  end
+
+  def self.reverse_function
+    {
+      title_case: :downcase, # Those two are best-effort,
+      downcase: :title_case, # but probably wrong.
+
+      compose: :decompose,
+      decompose: :compose,
+
+      separate: :unseparate,
+      unseparate: :separate
+    }
   end
 
   module Functions
@@ -177,8 +190,13 @@ class Interscript::Stdlib
       output
     end
 
-    def self.downcase(output, _:nil)
-      output.downcase
+    def self.downcase(output, word_separator: nil)
+      if word_separator
+        output = output.gsub(/^(.)/, &:downcase)
+        output = output.gsub(/#{word_separator}(.)/, &:downcase) unless word_separator == ''
+      else
+        output.downcase
+      end
     end
 
     def self.compose(output, _:nil)
@@ -191,6 +209,10 @@ class Interscript::Stdlib
 
     def self.separate(output, separator: " ")
       output.split("").join(separator)
+    end
+
+    def self.unseparate(output, separator: " ")
+      output.split(separator).join("")
     end
 
     @secryst_models = {}

--- a/ruby/lib/interscript/utils/helpers.rb
+++ b/ruby/lib/interscript/utils/helpers.rb
@@ -1,0 +1,39 @@
+module Interscript::Utils
+  module Helpers
+    def document name=nil, &block
+      $example_id ||= 0
+      $example_id += 1
+      name ||= "example-#{$example_id}"
+
+      Interscript::DSL::Document.new(name, &block).node.tap do |i|
+        $documents ||= {}
+        $documents[name] = i
+      end
+    end
+
+    def stage &block
+      document {
+        stage(&block)
+      }
+    end
+  end
+end
+
+class Interscript::Node::Document
+  def call(str, stage=:main, compiler=$compiler || Interscript::Interpreter, **kwargs)
+    compiler.(self).(str, stage, **kwargs)
+  end
+end
+
+module Interscript::DSL
+  class << self
+    alias original_parse parse
+    def parse(map_name)
+      if $documents && $documents[map_name]
+        $documents[map_name]
+      else
+        original_parse(map_name)
+      end
+    end
+  end
+end

--- a/ruby/lib/interscript/utils/helpers.rb
+++ b/ruby/lib/interscript/utils/helpers.rb
@@ -28,11 +28,11 @@ end
 module Interscript::DSL
   class << self
     alias original_parse parse
-    def parse(map_name)
+    def parse(map_name, **kwargs)
       if $documents && $documents[map_name]
         $documents[map_name]
       else
-        original_parse(map_name)
+        original_parse(map_name, **kwargs)
       end
     end
   end

--- a/ruby/spec/composability_spec.rb
+++ b/ruby/spec/composability_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "composability" do
+  it "can depend on reversed maps" do
+    a = document("part-1-One-Two") {
+      stage {
+        sub "a", "b"
+      }
+    }
+
+    b = document("part-2-One-Two") {
+      stage {
+        sub "c", "d"
+      }
+    }
+
+    c = document("composed") {
+      dependency "part-1-Two-One", as: twoone
+      dependency "part-2-One-Two", as: onetwo
+
+      stage {
+        run map.twoone.stage.main
+        run map.onetwo.stage.main
+      }
+    }
+
+    expect(c.("abcd")).to eq("aadd")
+  end
+
+  it "can seamlessly compose two maps" do
+    a = document("part1") {
+      stage {
+        sub "a", "b"
+      }
+    }
+    b = document("part2") {
+      stage {
+        sub "c", "d"
+      }
+    }
+
+    c = document("composed2") {
+      dependency "part1|part2", as: composed
+
+      stage {
+        run map.composed.stage.main
+      }
+    }
+
+    expect(c.("abcd")).to eq("bbdd")
+  end
+end

--- a/ruby/spec/interscript_spec.rb
+++ b/ruby/spec/interscript_spec.rb
@@ -19,23 +19,29 @@ RSpec.describe Interscript do
     describe compiler do
       maps.each do |system_file|
         system_name = File.basename(system_file, ".imp")
-        context "#{system_name} system" do
+        if ENV["REVERSE"]
+          my_system_name = Interscript::Node::Document.reverse_name(system_name)
+        else
+          my_system_name = system_name
+        end
+        context "#{my_system_name} system" do
           begin
             system = Interscript.parse(system_name)
+            system = system.reverse if ENV["REVERSE"]
 
             if system.tests && system.tests.data && system.tests.data.length > 0
               system.tests.data.each do |from,expected|
                 testname = from[0...300].gsub("\n", " / ")
                 it "test for #{testname}" do
                   Timeout::timeout(5) do
-                    result = Interscript.transliterate(system_name, from, cache, compiler: compiler)
+                    result = Interscript.transliterate(my_system_name, from, cache, compiler: compiler)
                     expect(result).to eq(expected)
                   end
                 end
               end
             else
               it "can successfully run a dummy test" do
-                result = Interscript.transliterate(system_name, "", cache, compiler: compiler)
+                result = Interscript.transliterate(my_system_name, "", cache, compiler: compiler)
                 expect(result).to eq("")
               end
               if ENV["REQUIRE_TESTS"]

--- a/ruby/spec/reversibility_spec.rb
+++ b/ruby/spec/reversibility_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "Reversibility" do
       expect(b.("ab")).to eq("ab")
     end
 
-    xit "transliterates correctly with reverse_run and parallel" do
+    it "transliterates correctly with reverse_run and parallel" do
       a = stage {
         parallel {
           sub "a", "b", reverse_run: true
@@ -241,7 +241,7 @@ RSpec.describe "Reversibility" do
       b = a.reverse
 
       expect(a.("abcd")).to eq("abdd")
-      expect(b.("abcd")).to eq("bbcd")
+      expect(b.("abcd")).to eq("aacd")
     end
   end
 

--- a/ruby/spec/reversibility_spec.rb
+++ b/ruby/spec/reversibility_spec.rb
@@ -1,0 +1,248 @@
+RSpec.describe "Reversibility" do
+  describe "stage tests" do
+    it "reverses a basic stage" do
+      a = stage {
+        sub "a", "b"
+      }
+
+      b = stage {
+        sub "b", "a"
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses a multirule stage" do
+      a = stage {
+        sub "a", "b"
+        sub "c", "d"
+      }
+
+      b = stage {
+        sub "d", "c"
+        sub "b", "a"
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses a multirule stage and preserves before/after" do
+      a = stage {
+        sub "a", "b", before: "c"
+        sub "c", "d", after: "d"
+      }
+
+      b = stage {
+        sub "d", "c", after: "d"
+        sub "b", "a", before: "c" 
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses a multirule stage and preserves not before/not after" do
+      a = stage {
+        sub "a", "b", not_before: "c"
+        sub "c", "d", not_after: "d"
+      }
+
+      b = stage {
+        sub "d", "c", not_after: "d"
+        sub "b", "a", not_before: "c" 
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses a parallel stage" do
+      a = stage {
+        parallel {
+          sub "a", "b"
+          sub "c", "d"
+          sub "e", "f"
+        }
+      }
+
+      b = stage {
+        parallel {
+          sub "f", "e"
+          sub "d", "c"
+          sub "b", "a"
+        }
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses a parallel stage and other rules if present" do
+      a = stage {
+        sub "X", "Y"
+        parallel {
+          sub "a", "b"
+          sub "c", "d"
+          sub "e", "f"
+        }
+      }
+
+      b = stage {
+        parallel {
+          sub "f", "e"
+          sub "d", "c"
+          sub "b", "a"
+        }
+        sub "Y", "X"
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "reverses with reverse_run correctly" do
+      a = stage {
+        sub "X", "Y", reverse_run: true
+        parallel {
+          sub "a", "b", reverse_run: false
+          sub "c", "d"
+          sub "e", "f"
+        }
+      }
+
+      b = stage {
+        parallel {
+          sub "f", "e"
+          sub "d", "c"
+          sub "b", "a", reverse_run: true
+        }
+        sub "Y", "X", reverse_run: false
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+  end
+
+  describe "item tests" do
+    it "transforms boundary" do
+      a = stage {
+        sub "a"+boundary, "b"
+      }
+
+      b = stage {
+        sub "b"+boundary, "a"
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "transforms captures and references" do
+      a = stage {
+        sub capture("a"), ref(1)+"b"
+      }
+
+      b = stage {
+        sub capture("a")+"b", ref(1)
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+
+    it "doesn't transform any" do
+      a = stage {
+        sub any("ab"), any("bc")
+      }
+
+      b = stage {
+        sub any("bc"), any("ab")
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+  end
+
+  describe "document transformations" do
+    it "transforms document name correctly when it transforms between different character sets" do
+      a = document("var-kor-Kore-Hang-test") { }
+
+      expect(a.reverse.name).to eq("var-kor-Hang-Kore-test")
+    end
+
+    it "transforms document name correctly when it transforms between the same character sets" do
+      a = document("var-swe-Latn-Latn-test") { }
+
+      expect(a.reverse.name).to eq("var-swe-Latn-Latn-test-reverse")
+    end
+
+    it "transforms input and output charset in metadata correctly" do
+      a = document {}
+      a.metadata = Interscript::Node::MetaData.new
+      a.metadata[:source_script] = "Hani"
+      a.metadata[:destination_script] = "Latn"
+
+      b = a.reverse
+      expect(b.metadata[:source_script]).to eq("Latn")
+      expect(b.metadata[:destination_script]).to eq("Hani")
+    end
+
+    it "transforms tests" do
+      a = document {
+        tests {
+          test "a", "b"
+          test "c", "d"
+        }
+      }
+
+      b = document {
+        tests {
+          test "b", "a"
+          test "d", "c"
+        }
+      }
+
+      expect(a.reverse).to eq(b)
+    end
+  end
+
+  describe "reverse_run" do
+    it "transliterates correctly with reverse_run: nil" do
+      a = stage {
+        sub "a", "b"
+      }
+      b = a.reverse
+
+      expect(a.("ab")).to eq("bb")
+      expect(b.("ab")).to eq("aa")
+    end
+
+    it "transliterates correctly with reverse_run: true" do
+      a = stage {
+        sub "a", "b", reverse_run: true
+      }
+      b = a.reverse
+
+      expect(a.("ab")).to eq("ab")
+      expect(b.("ab")).to eq("aa")
+    end
+
+    it "transliterates correctly with reverse_run: false" do
+      a = stage {
+        sub "a", "b", reverse_run: false
+      }
+      b = a.reverse
+
+      expect(a.("ab")).to eq("bb")
+      expect(b.("ab")).to eq("ab")
+    end
+
+    xit "transliterates correctly with reverse_run and parallel" do
+      a = stage {
+        parallel {
+          sub "a", "b", reverse_run: true
+          sub "c", "d", reverse_run: false
+        }
+      }
+      b = a.reverse
+
+      expect(a.("abcd")).to eq("abdd")
+      expect(b.("abcd")).to eq("bbcd")
+    end
+  end
+
+end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require "bundler/setup"
 require "interscript"
 require "interscript/compiler/ruby"
 require "interscript/compiler/javascript" unless ENV["SKIP_JS"]
+require "interscript/utils/helpers"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -21,22 +22,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  def document name=nil, &block
-    $example_id ||= 0
-    $example_id += 1
-    name ||= "example-#{$example_id}"
-
-    Interscript::DSL::Document.new(name, &block).node.tap do |i|
-      $documents ||= {}
-      $documents[name] = i
-    end
-  end
-
-  def stage &block
-    document {
-      stage(&block)
-    }
-  end
+  include Interscript::Utils::Helpers
 
   def each_compiler &block
     compilers = []
@@ -46,25 +32,6 @@ RSpec.configure do |config|
 
     compilers.each do |compiler|
       block.(compiler)
-    end
-  end
-end
-
-class Interscript::Node::Document
-  def call(str, stage=:main, compiler=$compiler || Interscript::Interpreter, **kwargs)
-    compiler.(self).(str, stage, **kwargs)
-  end
-end
-
-module Interscript::DSL
-  class << self
-    alias original_parse parse
-    def parse(map_name)
-      if $documents && $documents[map_name]
-        $documents[map_name]
-      else
-        original_parse(map_name)
-      end
     end
   end
 end


### PR DESCRIPTION
**This is a work in progress, but comments are more than welcome**

Throughout the codebase various nodes now support #reverse method. Those nodes, while constructing, also support a reverse_run switch which means, for 3 examples:

```ruby
sub "a", "b", reverse_run: true
```

This rule will exist as: `sub "b", "a", reverse_run: false` when reversed and will only be run when the map has been reversed.

```ruby
sub "a", "b", reverse_run: false
```

This rule will run only when un-reversed.

Normally, reverse_run is nil, which means it will run both in the reverse mode and in non-reverse mode.

Some examples already run in reverse mode:

```shell
$ REVERSE=true bundle exec rspec ./spec/interscript_spec.rb[1:1]
Finished in 24.93 seconds (files took 3.72 seconds to load)
7765 examples, 6391 failures
```

You can run a map in reverse this way: for instance, if map name is "alalc-ell-Grek-Latn-2010", you provide the map name either as: "alalc-ell-Latn-Grek-2010" or "alalc-ell-Grek-Latn-2010-reverse", for instance:

```shell
$ bin/interscript /dev/stdin -s alalc-ell-Latn-Grek-2010
Ellada
(Ctrl+D pressed)
Έλλαδα'
'
$
```

You can also preview how reversing works with console:

```ruby
$ bin/console
[6] pry(main)> gl = Interscript.parse("bgnpcgn-deu-Latn-Latn-2000").stages[:main]
=> stage {
  sub "β"+capture(upper), "SS"+ref(1), before: any(nil)
  sub "Ä"+capture(upper), "AE"+ref(1), before: any(nil)
  sub "Ö"+capture(upper), "OE"+ref(1), before: any(nil)
  sub "Ü"+capture(upper), "UE"+ref(1), before: any(nil)
  parallel {
    sub "Ä", "Ae"
    sub "Ö", "Oe"
    sub "Ü", "Ue"
    sub "ä", "ae"
    sub "ö", "oe"
    sub "ü", "ue"
    sub "β", "ss"
  }
}
[7] pry(main)> gl.reverse
=> stage {
  parallel {
    sub "ss", "β"
    sub "ue", "ü"
    sub "oe", "ö"
    sub "ae", "ä"
    sub "Ue", "Ü"
    sub "Oe", "Ö"
    sub "Ae", "Ä"
  }
  sub "UE"+ref(1), "Ü"+capture(upper), reverse_before: any(nil)
  sub "OE"+ref(1), "Ö"+capture(upper), reverse_before: any(nil)
  sub "AE"+ref(1), "Ä"+capture(upper), reverse_before: any(nil)
  sub "SS"+ref(1), "β"+capture(upper), reverse_before: any(nil)
}
[8] pry(main)> 
```

reverse_before and friends are ignored in general, they only become before when reversed. Do note the bug: capturing and references aren't switched yet.

There's no documentation or tests, this pull request is mostly a request for comments.