### PR TITLE
Visualize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,9 @@
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 /ruby/.rvmrc
 
-# Don't bundle visualizations
+# Don't bundle generated files
 /ruby/visualizations
+/ruby/json
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 /ruby/.rvmrc
 
+# Don't bundle visualizations
+/ruby/visualizations
+
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 /js/src/maps

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@
 # Don't bundle generated files
 /ruby/visualizations
 /ruby/json
+/ruby/vis_json
 /ruby/metadata.json
 /ruby/compiled
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@
 # Don't bundle generated files
 /ruby/visualizations
 /ruby/json
+/ruby/metadata.json
+/ruby/compiled
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,10 +1,10 @@
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :compile, [:compiler, :target] do |t, args|
-  require "bundler/setup"
   require "interscript"
 
   compiler, ext = case args[:compiler]
@@ -48,6 +48,20 @@ task :version, [:ver] do |t, ver|
   File.write(rubyfile, rubyver)
   File.write(jsfile,   jsver)
   File.write(mapsfile, mapsver)
+end
+
+task :visualize do
+  require "fileutils"
+  require "interscript"
+  require "interscript/visualize"
+
+  FileUtils.rm_rf(dir = __dir__+"/visualizations/")
+  FileUtils.mkdir_p(dir)
+
+  Interscript.maps.each do |map|
+    html = Interscript::Visualize.(map)
+    File.write(dir+map+".html", html)
+  end
 end
 
 task :default => :spec

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -50,7 +50,7 @@ task :version, [:ver] do |t, ver|
   File.write(mapsfile, mapsver)
 end
 
-task :visualize do
+task :generate_visualization_html do
   require "fileutils"
   require "interscript"
   require "interscript/visualize"
@@ -89,6 +89,24 @@ task :generate_json do
   (Interscript.maps + Interscript.maps(libraries: true)).each do |map|
     json = JSON.pretty_generate(Interscript.parse(map).to_hash)
     File.write(dir+map+".json", json)
+  end
+end
+
+task :generate_visualization_json do
+  require "fileutils"
+  require "interscript"
+  require "json"
+  require "interscript/visualize"
+
+  FileUtils.rm_rf(dir = __dir__+"/vis_json/")
+  FileUtils.mkdir_p(dir)
+
+  (Interscript.maps + Interscript.maps(libraries: true)).each do |map_name|
+    map = Interscript.parse(map_name)
+    map.stages.each do |stage_name, stage|
+      json = JSON.pretty_generate(stage.to_visualization_array(map))
+      File.write(dir+map_name+"_#{stage_name}.json", json)
+    end
   end
 end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -64,4 +64,18 @@ task :visualize do
   end
 end
 
+task :generate_json do
+  require "fileutils"
+  require "json"
+  require "interscript"
+
+  FileUtils.rm_rf(dir = __dir__+"/json/")
+  FileUtils.mkdir_p(dir)
+
+  (Interscript.maps + Interscript.maps(libraries: true)).each do |map|
+    json = JSON.pretty_generate(Interscript.parse(map).to_hash)
+    File.write(dir+map+".json", json)
+  end
+end
+
 task :default => :spec

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -64,6 +64,20 @@ task :visualize do
   end
 end
 
+task :generate_metadata_json do
+  require "fileutils"
+  require "json"
+  require "interscript"
+
+  FileUtils.rm_rf(file = __dir__+"/metadata.json")
+
+  hash = Interscript.maps.map do |map|
+    [map, Interscript.parse(map).metadata.to_hash]
+  end.to_h
+
+  File.write(file, JSON.pretty_generate(hash))
+end
+
 task :generate_json do
   require "fileutils"
   require "json"

--- a/ruby/lib/interscript/dsl.rb
+++ b/ruby/lib/interscript/dsl.rb
@@ -7,6 +7,7 @@ module Interscript::DSL
 
     return @cache[map_name] if @cache[map_name]
     path = Interscript.locate(map_name)
+    library = path.end_with?(".iml")
     map_name = File.basename(path, ".imp")
     map_name = File.basename(map_name, ".iml")
 
@@ -45,7 +46,7 @@ module Interscript::DSL
       YAML.load(yaml, exc_fname)
     end
 
-    md = Interscript::DSL::Metadata.new(yaml: true) do
+    md = Interscript::DSL::Metadata.new(yaml: true, map_name: map_name, library: library) do
       yaml.each do |k,v|
         public_send(k.to_sym, v)
       end

--- a/ruby/lib/interscript/dsl/metadata.rb
+++ b/ruby/lib/interscript/dsl/metadata.rb
@@ -1,26 +1,68 @@
+require 'date'
+
 class Interscript::DSL::Metadata
   attr_accessor :node
 
-  def initialize(yaml: false, &block)
+  def initialize(yaml: false, map_name: "", library: true, &block)
     raise ArgumentError, "Can't evaluate metadata from Ruby context" unless yaml
+    @map_name = map_name
     @node = Interscript::Node::MetaData.new
     self.instance_exec(&block)
+    @node[:nonstandard] = {}
+
+    NECESSARY_KEYS.each do |i|
+      unless @node.data.key? i
+        warn "[#{@map_name}] Necessary key #{i} wasn't defined. Defaulting to an empty string"
+        @node[i] = ""
+      end
+    end unless library
   end
 
-  %i{authority_id id language source_script
-    destination_script name url creation_date
-    adoption_date description character notes
-    source confirmation_date}.each do |sym|
+  STANDARD_STRING_KEYS = %i{authority_id id
+  language source_script destination_script
+  name url creation_date adoption_date description
+  character source confirmation_date}
+
+  STANDARD_ARRAY_KEYS = %i{notes}
+
+  NONSTANDARD_KEYS = %i{special_rules original_description original_notes
+    implementation_notes}
+  
+  NECESSARY_KEYS = %i{name language source_script destination_script}
+
+  STANDARD_STRING_KEYS.each do |sym|
     define_method sym do |stuff|
-      @node[sym] = stuff
+      case stuff
+      when String, Integer, Date
+        @node[sym] = stuff.to_s
+      when NilClass
+      else
+        warn "[#{@map_name}] Metadata key #{sym} expects a String, but #{stuff.class} was given"
+        @node[sym] = stuff.inspect
+      end
     end
   end
 
-  %i{special_rules original_description original_notes
-    implementation_notes}.each do |sym|
+  STANDARD_ARRAY_KEYS.each do |sym|
     define_method sym do |stuff|
-      warn "Metadata key #{sym} is non-standard"
-      @node[sym] = stuff
+      stuff = Array(stuff)
+
+      stuff.map do |i|
+        case i
+        when String
+          i
+        else
+          warn "[#{@map_name}] Metadata key #{sym} expects all Array elements to be String"
+          i.inspect
+        end
+      end
+    end
+  end
+
+  NONSTANDARD_KEYS.each do |sym|
+    define_method sym do |stuff|
+      warn "[#{@map_name}] Metadata key #{sym} is non-standard"
+      (@node[:nonstandard] ||= {})[sym] = stuff
     end
   end
 end

--- a/ruby/lib/interscript/node/item/any.rb
+++ b/ruby/lib/interscript/node/item/any.rb
@@ -51,8 +51,23 @@ class Interscript::Node::Item::Any < Interscript::Node::Item
   end
 
   def to_hash
-    { :class => self.class.to_s,
-      :data => self.data.map { |i| i.to_hash } }
+    hash = { :class => self.class.to_s }
+
+    case @value
+    when Array
+      hash[:type] = "Array"
+      hash[:data] = data.map { |i| i.to_hash }
+    when ::String
+      hash[:type] = "String"
+      hash[:data] = @value
+    when Range
+      hash[:type] = "Range"
+      hash[:data] = [@value.begin, @value.end]
+    when NilClass
+      hash[:type] = "nil (bug)"
+    end
+
+    hash
   end
 
   def inspect

--- a/ruby/lib/interscript/node/rule/sub.rb
+++ b/ruby/lib/interscript/node/rule/sub.rb
@@ -35,15 +35,18 @@ class Interscript::Node::Rule::Sub < Interscript::Node::Rule
   def to_hash
     puts self.from.inspect if $DEBUG
     puts params.inspect if $DEBUG
-    { :class => self.class.to_s,
+    hash = { :class => self.class.to_s,
       :from => self.from.to_hash,
-      :to => self.to == :upcase ? :upcase : self.to.to_hash,
-      :before => self.before&.to_hash,
-      :not_before => self.not_before&.to_hash,
-      :after => self.after&.to_hash,
-      :not_after => self.not_after&.to_hash,
-      :priority => self.priority
+      :to => Symbol === self.to ? self.to : self.to.to_hash
     }
+
+    hash[:before] = self.before&.to_hash if self.before
+    hash[:not_before] = self.not_before&.to_hash if self.not_before
+    hash[:after] = self.after&.to_hash if self.after
+    hash[:not_after] = self.not_after&.to_hash if self.not_after
+    hash[:priority] = self.priority if self.priority
+
+    hash
   end
 
   def inspect

--- a/ruby/lib/interscript/visualize.rb
+++ b/ruby/lib/interscript/visualize.rb
@@ -1,0 +1,18 @@
+require 'erb'
+
+class Interscript::Visualize
+  @template = ERB.new(File.read(__dir__+"/visualize/map.html.erb"))
+
+  def self.call(map_name)
+    tplctx = self.new(Interscript.parse(map_name))
+    @template.result(tplctx.get_binding)
+  end
+
+  def get_binding; binding; end
+
+  def initialize(map)
+    @map = map
+  end
+
+  attr_reader :map
+end

--- a/ruby/lib/interscript/visualize.rb
+++ b/ruby/lib/interscript/visualize.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'interscript/visualize/nodes'
+require 'interscript/visualize/json'
 
 def h(str)
   str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")

--- a/ruby/lib/interscript/visualize.rb
+++ b/ruby/lib/interscript/visualize.rb
@@ -1,4 +1,9 @@
 require 'erb'
+require 'interscript/visualize/nodes'
+
+def h(str)
+  str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
+end
 
 class Interscript::Visualize
   def self.def_template(template)
@@ -9,23 +14,15 @@ class Interscript::Visualize
   def self.call(*args)
     return Map.(*args) if self == Interscript::Visualize
 
-    tplctx = self.new(*select_object(*args))
+    tplctx = self.new(*args)
     @template.result(tplctx.get_binding)
-  end
-
-  def h(str)
-    str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
   end
 
   class Map < self
     def_template :map
 
-    def self.select_object(map_name)
-      Interscript.parse(map_name)
-    end
-
-    def initialize(map)
-      @map = map
+    def initialize(map_name)
+      @map = Interscript.parse(map_name)
     end
 
     attr_reader :map
@@ -35,17 +32,29 @@ class Interscript::Visualize
     end
   end
 
-  class Stage < self
-    def_template :stage
+  class Group < self
+    def_template :group
 
-    def self.select_object(map_name, stage_name)
-      Interscript.parse(map_name).stages[stage_name]
-    end
-  
-    def initialize(stage)
-      @stage = stage
+    def initialize(map, group, style=nil)
+      @map = map
+      @group = group
+      @style = style
     end
 
-    attr_reader :stage
+    attr_reader :map, :group
+
+    def render_group(map, group, style=nil)
+      Group.(map, group, style)
+    end
+  end
+
+  class Stage < Group
+    def_template :group
+
+    def initialize(map_name, stage_name, style=nil)
+      @map = Interscript.parse(map_name)
+      @group = map.stages[stage_name]
+      @style = style
+    end
   end  
 end

--- a/ruby/lib/interscript/visualize.rb
+++ b/ruby/lib/interscript/visualize.rb
@@ -1,18 +1,51 @@
 require 'erb'
 
 class Interscript::Visualize
-  @template = ERB.new(File.read(__dir__+"/visualize/map.html.erb"))
+  def self.def_template(template)
+    @template = ERB.new(File.read(__dir__+"/visualize/#{template}.html.erb"))
+  end
+  def get_binding; binding; end
 
-  def self.call(map_name)
-    tplctx = self.new(Interscript.parse(map_name))
+  def self.call(*args)
+    return Map.(*args) if self == Interscript::Visualize
+
+    tplctx = self.new(*select_object(*args))
     @template.result(tplctx.get_binding)
   end
 
-  def get_binding; binding; end
-
-  def initialize(map)
-    @map = map
+  def h(str)
+    str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
   end
 
-  attr_reader :map
+  class Map < self
+    def_template :map
+
+    def self.select_object(map_name)
+      Interscript.parse(map_name)
+    end
+
+    def initialize(map)
+      @map = map
+    end
+
+    attr_reader :map
+
+    def render_stage(map_name, stage)
+      Stage.(map_name, stage)
+    end
+  end
+
+  class Stage < self
+    def_template :stage
+
+    def self.select_object(map_name, stage_name)
+      Interscript.parse(map_name).stages[stage_name]
+    end
+  
+    def initialize(stage)
+      @stage = stage
+    end
+
+    attr_reader :stage
+  end  
 end

--- a/ruby/lib/interscript/visualize/group.html.erb
+++ b/ruby/lib/interscript/visualize/group.html.erb
@@ -1,0 +1,59 @@
+<table style='<%= @style %>'>
+  <% group.children.each do |rule| %>
+    <tr>
+      <% case rule
+         when Interscript::Node::Rule::Sub %>
+        <td>
+          Replace
+        <td>
+          <%= rule.from.to_html(map) %>
+        <td>
+          <%= Symbol === rule.to ? rule.to : rule.to.to_html(map) %>
+        <td>
+          <%=
+            out = []
+            out << "before: #{rule.before.to_html(map)}" if rule.before
+            out << "after: #{rule.after.to_html(map)}" if rule.after
+            out << "<nobr>not before:</nobr> #{rule.not_before.to_html(map)}" if rule.not_before
+            out << "<nobr>not after:</nobr> #{rule.not_after.to_html(map)}" if rule.not_after
+            out.join(", ")
+          %>
+      <% when Interscript::Node::Group::Parallel %>
+        <td>
+          Parallel
+        <td colspan='3'>
+          <%= render_group map, rule %>
+        </td>
+      <% when Interscript::Node::Rule::Funcall %>
+        <td>
+          <%= h rule.name.to_s.gsub("_", " ").gsub(/^(.)/, &:upcase) %>
+        <td>
+          <%=
+            rule.kwargs.map do |k,v|
+              "#{k.to_s.gsub("_", " ")}: #{v}"
+            end.join(", ")
+          %>
+      <% when Interscript::Node::Rule::Run %>
+        <td>
+          <nobr>Run</nobr>
+        <td>
+          <a href='#' onclick='this.parentNode.lastElementChild.style.display=this.parentNode.lastElementChild.style.display=="none"?"table":"none";return!1'>
+            <%= rule.stage.to_html(map) %>
+          </a>
+
+          <%=
+            if rule.stage.map
+              doc = map.dep_aliases[rule.stage.map].document
+              stage = doc.imported_stages[rule.stage.name]
+            else
+              doc = map
+              stage = map.imported_stages[rule.stage.name]
+            end
+
+            render_group doc, stage, "display: none"
+          %>
+      <% else %>
+        <td colspan='4'><pre><%= h rule.inspect %></pre>
+      <% end %>
+  <% end %>
+</table>

--- a/ruby/lib/interscript/visualize/json.rb
+++ b/ruby/lib/interscript/visualize/json.rb
@@ -1,0 +1,57 @@
+class Interscript::Node::Group
+  def to_visualization_array(map=self)
+    out = []
+
+    self.children.each do |rule|
+      case rule
+      when Interscript::Node::Rule::Sub
+        more = []
+        more << "before: #{rule.before.to_html(map)}" if rule.before
+        more << "after: #{rule.after.to_html(map)}" if rule.after
+        more << "<nobr>not before:</nobr> #{rule.not_before.to_html(map)}" if rule.not_before
+        more << "<nobr>not after:</nobr> #{rule.not_after.to_html(map)}" if rule.not_after
+        more = more.join(", ")
+
+        out << {
+          type: "Replace",
+          from: rule.from.to_html(map),
+          to: Symbol === rule.to ? rule.to : rule.to.to_html(map),
+          more: more
+        }
+      when Interscript::Node::Group::Parallel
+        out << {
+          type: "Parallel",
+          children: rule.to_visualization_array(map)
+        }
+      when Interscript::Node::Rule::Funcall
+        out << {
+          type: rule.name.to_s.gsub("_", " ").gsub(/^(.)/, &:upcase),
+          more: rule.kwargs.map do |k,v|
+            "#{k.to_s.gsub("_", " ")}: #{v}"
+          end.join(", ")
+        }
+      when Interscript::Node::Rule::Run
+        if rule.stage.map
+          doc = map.dep_aliases[rule.stage.map].document
+          stage = rule.stage.name
+        else
+          doc = map
+          stage = rule.stage.name
+        end
+
+        out << {
+          type: "Run",
+          doc: doc.name,
+          stage: stage
+        }
+      else
+        out << {
+          type: "Unknown",
+          more: "<pre>#{h rule.inspect}</pre>"
+        }
+      end
+    end
+
+    out
+  end
+end

--- a/ruby/lib/interscript/visualize/map.html.erb
+++ b/ruby/lib/interscript/visualize/map.html.erb
@@ -1,0 +1,44 @@
+<h1><%= map.name %></h1>
+
+<dl>
+<% map.metadata.data.each do |k,v| %>
+  <% case k
+     when :authority_id %>
+    <dt>Authority ID
+  <% when :id %>
+    <dt>Standard ID
+  <% when :language %>
+    <dt>Language
+  <% when :source_script %>
+    <dt>Source script
+  <% when :destination_script %>
+    <dt>Destination script
+  <% when :name %>
+    <dt>Name
+  <% when :url %>
+    <dt>URL
+  <% when :creation_date %>
+    <dt>Creation date
+  <% when :confirmation_date %>
+    <dt>Confirmation date
+  <% when :adoption_date %>
+    <dt>Adoption date
+  <% when :description %>
+    <dt>Description
+  <% when :source %>
+    <dt>Source
+  <% when :notes, :implementation_notes, :special_rules, :original_notes, :original_description # We ignore notes for now %>
+  <% else %>
+  <% p [k, v, map.name] %>
+    <dt><%= k %>
+  <% end %>
+
+  <% case k
+     when :url %>
+    <dd><a href='<%= v %>'><%= v %></a>
+  <% when :notes, :implementation_notes, :special_rules, :original_notes, :original_description # We ignore notes for now %>
+  <% else %>
+    <dd><%= v %>
+  <% end %>
+<% end %>
+</dl>

--- a/ruby/lib/interscript/visualize/map.html.erb
+++ b/ruby/lib/interscript/visualize/map.html.erb
@@ -1,4 +1,4 @@
-<h1><%= map.name %></h1>
+<h1><%= h map.name %></h1>
 
 <dl>
 <% map.metadata.data.each do |k,v| %>
@@ -30,15 +30,17 @@
   <% when :notes, :implementation_notes, :special_rules, :original_notes, :original_description # We ignore notes for now %>
   <% else %>
   <% p [k, v, map.name] %>
-    <dt><%= k %>
+    <dt><%= h k %>
   <% end %>
 
   <% case k
      when :url %>
-    <dd><a href='<%= v %>'><%= v %></a>
+    <dd><a href="<%= h v %>"><%= h v %></a>
   <% when :notes, :implementation_notes, :special_rules, :original_notes, :original_description # We ignore notes for now %>
   <% else %>
-    <dd><%= v %>
+    <dd><%= h v %>
   <% end %>
 <% end %>
 </dl>
+
+<%= render_stage(self.map.name, :main) %>

--- a/ruby/lib/interscript/visualize/nodes.rb
+++ b/ruby/lib/interscript/visualize/nodes.rb
@@ -1,0 +1,89 @@
+class Interscript::Node::Item
+  class Alias < self
+    def to_html(doc)
+      if map
+        n = doc.dep_aliases[map].full_name
+        "#{name.to_s.gsub("_", " ")} from map #{n}"
+      else
+        "#{name.to_s.gsub("_", " ")}"
+      end
+    end
+  end
+
+  class Stage < self
+    def to_html(doc)
+      if map
+        n = doc.dep_aliases[map].full_name
+        "stage #{name.to_s.gsub("_", " ")} from map #{n}"
+      else
+        "#{name.to_s.gsub("_", " ")}"
+      end
+    end
+  end
+
+  class Any < self
+    def to_html(doc)
+      "<nobr>any (</nobr>" +
+        case @value
+        when Array
+          value.map(&Interscript::Node::Item.method(:try_convert)).map{|i|i.to_html(doc)}.join(", ")
+        when ::String
+          value.split("").map(&Interscript::Node::Item.method(:try_convert)).map{|i|i.to_html(doc)}.join(", ")
+        when Range
+          [value.begin, value.end].map(&Interscript::Node::Item.method(:try_convert)).map{|i|i.to_html(doc)}.join(" to ")
+        else
+          h(value.inspect)
+        end +
+      ")"
+    end
+  end
+
+  class CaptureGroup < self
+    def to_html(doc)
+      "<nobr>capture group (</nobr>" +
+        data.to_html(doc) +
+      ")"
+    end
+  end
+
+  class CaptureRef < self
+    def to_html(_)
+      "<nobr>capture reference (</nobr>" +
+        id.to_s +
+      ")"
+    end
+  end
+
+  class Group < self
+    def to_html(doc)
+      @children.map{|i|i.to_html(doc)}.join(" + ")
+    end
+  end
+
+  class Repeat < self
+    def to_html(doc)
+      str = case self
+      when Interscript::Node::Item::Maybe
+        "zero or one "
+      when Interscript::Node::Item::MaybeSome
+        "zero or more of "
+      when Interscript::Node::Item::Some
+        "one or more of "
+      end
+      "<nobr>#{str}(</nobr>#{@data.to_html(doc)})"
+    end
+  end
+
+  class String < self
+    def to_html(_)
+      out = ""
+      self.data.each_char do |i|
+        out << "<ruby>"
+        out << "<kbd>#{h i}</kbd>"
+        out << "<rt>#{"%04x" % i.ord}</rt>"
+        out << "</ruby>"
+      end
+      out
+    end
+  end
+end

--- a/ruby/lib/interscript/visualize/stage.html.erb
+++ b/ruby/lib/interscript/visualize/stage.html.erb
@@ -1,6 +1,0 @@
-<table>
-  <% stage.children.each do |rule| %>
-    <tr>
-      <td><pre><%= h rule.inspect %></pre>
-  <% end %>
-</table>

--- a/ruby/lib/interscript/visualize/stage.html.erb
+++ b/ruby/lib/interscript/visualize/stage.html.erb
@@ -1,0 +1,6 @@
+<table>
+  <% stage.children.each do |rule| %>
+    <tr>
+      <td><pre><%= h rule.inspect %></pre>
+  <% end %>
+</table>


### PR DESCRIPTION
This PR is related to support rake tasks for generating files as in use by the interscript/interscript.org repo, but those may be useful also for other purposes:

* `generate_visualization_html` - generates visualization HTML files, in use by the first version of the repo, may be useful to inspect the maps while developing them
* `generate_metadata_json` - generates metadata.json for all maps. Used by interscript.org.
* `generate_json` - generates json from #to_hash function for all maps. This offers us a full view into the map files from other environments. This isn't used by interscript.org now, but could be used to provide the best styling possible.
* `generate_visualization_json` - generates JSONs of a hybrid nature - in general they have a structure more similar to `visualization_html` than to `json`. Used by interscript.org.