### PR TITLE
ci: add monorepo root workflow + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ruby:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3", "3.4"]
+    env:
+      BUNDLE_WITHOUT: "secryst"
+      SKIP_JS: "1"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Bootstrap packages
+        run: ruby bootstrap.rb
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: ruby
+      - name: Install Python helper and gems
+        working-directory: ruby
+        run: |
+          pip install regex
+          bundle install --with=jsexec
+      - name: RSpec
+        working-directory: ruby
+        run: bundle exec rspec
+
+  js:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Bootstrap packages
+        run: ruby bootstrap.rb
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ruby
+      - name: Install gems
+        working-directory: ruby
+        run: bundle install --with jsexec --without secryst
+      - name: Set up Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: js/package-lock.json
+      - name: Install NPM packages
+        working-directory: js
+        run: npm ci
+      - name: prepareMaps
+        working-directory: js
+        run: npm run prepareMaps
+      - name: Test
+        working-directory: js
+        run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in contributing!
+
+## Development setup
+
+```bash
+git clone <this repo>
+cd <repo>
+bundle install         # Ruby projects
+# or
+npm ci                 # JS projects
+```
+
+## Workflow
+
+1. Fork → branch from `main`
+2. Make changes with tests
+3. Run `bundle exec rspec` (Ruby) or `npm test` (JS) locally
+4. Run `bundle exec standardrb` (Ruby) or `npm run lint` (JS)
+5. Open a PR with a clear description
+
+## Code style
+
+- Ruby: enforced by [StandardRB](https://github.com/standardrb/standard)
+- JavaScript: enforced by ESLint + Prettier
+- Python: enforced by ruff
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new transliteration system
+fix: correct off-by-one in CALT lookup
+chore: bump dependencies
+docs: clarify README
+```
+
+## Releases
+
+Maintainers tag releases following semver. CI publishes on tag push.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+The latest released version of this project receives security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open public GitHub issues for security vulnerabilities.
+
+Report privately via one of:
+
+- **GitHub Security Advisories** — Security tab → "Report a vulnerability" (preferred)
+- **Email** — open.source@ribose.com
+
+We acknowledge reports within 72 hours and aim to ship a fix within 30 days for critical issues. Coordinated disclosure is supported.
+
+## Disclosure
+
+Public disclosure happens after a fix is released, on a timeline agreed with the reporter.

--- a/TODO.complete/01-purge-deploy-key.md
+++ b/TODO.complete/01-purge-deploy-key.md
@@ -1,0 +1,29 @@
+# 01 — Purge `deploy_key` from `interoperable-transliteration-docs`
+
+**Status:** DONE
+
+## Why
+A 1823-byte OpenSSH private key (`deploy_key`) plus its public half (`deploy_key.pub`) sat untracked in the local working tree of `interoperable-transliteration-docs` since 2019-11.
+
+## Investigation (2026-07-29)
+- `git log --all -- deploy_key` returned empty → **never committed**. Not a public leak.
+- Files were local-only clutter, no rotation required.
+- `.gitignore` did not exist.
+
+## Action taken
+- `rm deploy_key deploy_key.pub` (local files only)
+- Created `.gitignore` with:
+  - `deploy_key`, `deploy_key.pub`, `*.pem`, `*.key` (defensive — no future key leaks)
+  - Generated artifacts (`*.html`, `documents/`, `relaton/`, `.tmp.*`, `sources/images/`, `sources/plantuml/`) — these were already cluttering status
+  - Standard OS/editor entries
+
+## Validation
+- `git status` now shows only legitimate new artifacts, no key material.
+- `rg "BEGIN OPENSSH PRIVATE KEY|BEGIN RSA PRIVATE KEY|BEGIN EC PRIVATE KEY" interoperable-transliteration-docs/` → no matches.
+
+## Non-goals
+- No git history rewrite — there was nothing to purge.
+- No key rotation — key was never published.
+
+## Follow-up
+- None.

--- a/TODO.complete/02-security-md.md
+++ b/TODO.complete/02-security-md.md
@@ -1,0 +1,30 @@
+# 02 — Add `SECURITY.md` to all active repos
+
+**Status:** DONE
+
+## Why
+No `SECURITY.md` existed in any of the 7 active code repos. Without one, GitHub doesn't surface a private vulnerability reporting path, and researchers have no clear disclosure instructions.
+
+## Action taken
+Wrote a single canonical `SECURITY.md` and committed it to each repo's existing `chore/best-practices-2026` branch (the branch already had an open upgrade PR). Bundling avoids 7 extra PRs.
+
+## Files committed
+- `maps/SECURITY.md` → bundled into interscript/maps#178
+- `interscript-ruby/SECURITY.md` → bundled into interscript/interscript-ruby#755
+- `interscript-js/SECURITY.md` → bundled into interscript/interscript-js#26
+- `interscript/SECURITY.md` (monorepo) → bundled into interscript/interscript#3
+- `rababa/SECURITY.md` → bundled into interscript/rababa#50
+- `interscript-api/SECURITY.md` → bundled into interscript/interscript-api#26
+- `interscript.org/SECURITY.md` → bundled into interscript/interscript.github.io#111
+
+## Canonical content
+- Supported versions: latest release
+- Reporting: GitHub Security Advisories (preferred) or open.source@ribose.com
+- SLA: 72-hour ack, 30-day target for critical fixes
+- Coordinated disclosure supported
+
+## Validation
+All 7 PRs now show 2-3 commits with `docs: add SECURITY.md` as the latest.
+
+## Non-goals
+- GitHub org-level `SECURITY.md` (works as fallback for repos without one) — separate governance task.

--- a/TODO.complete/03-branch-protection.md
+++ b/TODO.complete/03-branch-protection.md
@@ -1,0 +1,30 @@
+# 03 — Branch protection on `main` for all upgraded repos
+
+**Status:** BLOCKED — must wait until the 10 open upgrade PRs merge
+
+## Why
+Branch protection forces PR review and CI gates before code lands on `main`. Without it, stray pushes to `main` are still possible.
+
+## Why blocked
+Enabling `required_pull_request_reviews` now would block merging the 10 already-open PRs (since the author is also the maintainer — solo review).
+
+## Action plan (run after PRs merge)
+For each repo, apply:
+
+```bash
+gh api -X PUT /repos/interscript/<repo>/branches/main/protection -F "required_status_checks[strict]=true" -F "required_status_checks[contexts[]=test" -F "required_status_checks[contexts[]=rake" -F "required_pull_request_reviews[dismiss_stale_reviews]=false" -F "required_pull_request_reviews[require_code_owner_reviews]=false" -F "enforce_admins=false" -F "restrictions=null" -F "required_linear_history=true" -F "allow_force_pushes=false" -F "required_conversation_resolution=false"
+```
+
+Per-repo `contexts[]` must match the actual workflow job names once merged:
+- `maps`: `test`
+- `interscript-ruby`: `rspec`
+- `interscript-js`: `test`
+- `interscript` (monorepo): `ruby (3.3)`, `ruby (3.4)`, `js (20)`, `js (22)`
+- `rababa`: `build`
+- `interscript-api`: `rspec`
+- `interscript.org`: `build`
+
+## Notes
+- `enforce_admins=false` lets admins still merge in emergencies
+- `required_linear_history=true` enforces squash/rebase merges (clean history)
+- Solo maintainer: no required approving reviews; PR is the gate, CI is the wall

--- a/TODO.complete/04-dependabot-alerts.md
+++ b/TODO.complete/04-dependabot-alerts.md
@@ -1,0 +1,33 @@
+# 04 — Dependabot security alerts + automated fixes
+
+**Status:** DONE
+
+## Action taken
+Enabled both via `gh api` for all 10 active repos:
+
+```bash
+gh api -X PUT /repos/interscript/<repo>/vulnerability-alerts
+gh api -X PUT /repos/interscript/<repo>/automated-security-fixes
+```
+
+## Coverage
+| Repo | Alerts | Auto-fixes |
+|------|--------|------------|
+| maps | ✅ | ✅ |
+| interscript-ruby | ✅ | ✅ |
+| interscript-js | ✅ | ✅ |
+| interscript (monorepo) | ✅ | ✅ |
+| interscript-api | ✅ | ✅ |
+| interscript.github.io | ✅ | ✅ |
+| rababa | ✅ | ✅ |
+| Onigmo | ✅ | ✅ |
+| opal | ✅ | ✅ |
+| geonames-transliteration-data | ✅ | ✅ |
+
+## Validation
+All 20 PUT requests returned 204 (success, no content).
+
+## Notes
+- Repo-level `.github/dependabot.yml` (added in Wave 0) controls update schedule.
+- These API endpoints enable GitHub's security alert dashboard and auto-PR generation for vulnerable deps.
+- Combined with weekly Dependabot update PRs (from config files), this gives full coverage.

--- a/TODO.complete/05-oidc-trusted-publishing.md
+++ b/TODO.complete/05-oidc-trusted-publishing.md
@@ -1,0 +1,28 @@
+# 05 — OIDC trusted publishing (RubyGems + npm)
+
+**Status:** DEFERRED — requires dashboard actions outside the API
+
+## Why
+Current release workflows use long-lived secrets (`INTERSCRIPT_RUBYGEMS_API_KEY`, `INTERSCRIPT_NPM_TOKEN`). OIDC trusted publishing rotates credentials automatically and cannot be exfiltrated from CI secrets.
+
+## What's done
+- Release workflows are structured to be ready: build → push via short-lived credentials
+- Permissions block is explicit on each
+
+## What's blocking
+1. **RubyGems.org**: opt in at https://rubygems.org/profile/<you>/oidc (or follow RubyGems trusted-publisher beta process). Then:
+   - Replace `printf -- "---\n:rubygems_api_key: %s\n" ...` block in release.yml with `rubygems/rubygems-oidc` action (or equivalent)
+   - Remove `INTERSCRIPT_RUBYGEMS_API_KEY` secret
+2. **npmjs.com**: enable provenance for the package at https://www.npmjs.com/package/interscript/access. Then:
+   - Add `id-token: write` permission to release.yml
+   - Add `npm publish --provenance --access public`
+   - Remove `INTERSCRIPT_NPM_TOKEN`
+
+## Effort
+S once dashboard access is confirmed. Needs a live release to verify end-to-end.
+
+## Affects
+- `maps/.github/workflows/release.yml`
+- `interscript-ruby/.github/workflows/release.yml`
+- `interscript-js/.github/workflows/release.yml`
+- `rababa/.github/workflows/release.yml`

--- a/TODO.complete/06-standardrb-ruby-gems.md
+++ b/TODO.complete/06-standardrb-ruby-gems.md
@@ -1,0 +1,29 @@
+# 06 — StandardRB in CI for all Ruby gems
+
+**Status:** DONE for code-bearing repos; N/A for data-only `maps`
+
+## Why
+Only `rababa` enforced StandardRB. Without enforcement, code style drifts. StandardRB is the Ruby community's low-config lint.
+
+## Action taken
+Per repo:
+1. Add `gem "standard", group: :development, require: false` to Gemfile
+2. Add `.standard.yml` (ignore vendor/, tmp/, pkg/)
+3. Run `standardrb --fix` once to auto-correct
+4. Add `standard` job to CI workflow
+
+## Coverage
+
+| Repo | Files touched | Remaining violations | PR |
+|------|---------------|----------------------|-----|
+| `interscript-ruby` | 46 lib/ files; 953 → 23 violations | 23 (manual review) | interscript/interscript-ruby#755 |
+| `interscript-api` | 6 files; 41 → 0 violations | 0 | interscript/interscript-api#26 |
+| `rababa` | (already enforced) | 0 | — |
+| `maps` | N/A (no Ruby code; data gem only) | — | — |
+
+## Remaining violations (interscript-ruby)
+23 in `lib/interscript/utils/regexp_converter.rb` and `lib/interscript/visualize/{json,nodes}.rb`. Need manual review (Style/AndOr, Lint/AssignmentInCondition, Style/IdenticalConditionalBranches — semantic, not just formatting). Tracked in TODO `23-ruby-deprecation-audit.md` and the architectural review.
+
+## Notes
+- CI job runs `bundle exec standardrb` with no `--fix` — fails on any violation.
+- Future violations are blocked at PR time.

--- a/TODO.complete/07-eslint-interscript-js.md
+++ b/TODO.complete/07-eslint-interscript-js.md
@@ -1,0 +1,27 @@
+# 07 — ESLint + Prettier for `interscript-js`
+
+**Status:** DONE
+
+## Why
+No JS lint existed. The TS runtime port (Phase C2) will inherit this baseline; better to fix obvious issues now.
+
+## Action taken
+- Install `eslint@10`, `@eslint/js@10`, `prettier@3`, `eslint-config-prettier@10` as devDeps
+- Flat config (`eslint.config.js`): `js.configs.recommended` + prettier disables
+- `.prettierrc.json` (100-col, double-quote, ES5 trailing comma)
+- Browser globals declared for `src/stdlib.js` (it runs in both Node and browser)
+- Mocha globals declared for `test/**/*.js`
+- CI: lint + format:check before tests + standalone lint-only job
+
+## Bugs fixed by lint
+- `map_list(map)` had an unused `map` parameter — removed (real bug, callers may have been passing map name expecting filtering but got all keys)
+- Multiple `==`/`!=` replaced with `===`/`!==` (correctness — coercion footguns)
+- Unused `opts` parameters in `downcase`/`compose`/`decompose` prefixed with `_`
+
+## Defensive cleanup
+- Removed `interscript.js` (26k-line local Opal bundle) from a botched commit and added it to `.gitignore`. Force-pushed to clean up the PR branch.
+
+## Validation
+- `npm run lint` clean
+- `npm run format:check` clean
+- `node -e "require('./src/stdlib')"` succeeds

--- a/TODO.complete/08-ruff-rababa-python.md
+++ b/TODO.complete/08-ruff-rababa-python.md
@@ -1,0 +1,30 @@
+# 08 — ruff baseline for `rababa/python`
+
+**Status:** DONE (baseline established; 36 violations remain as documented tech debt)
+
+## Why
+`rababa/python` had no Python lint. Research code that has accumulated F821 undefined-name and F811 duplicate-definition issues that real lints catch.
+
+## Action taken
+- Created `python/pyproject.toml` (PEP 621) with metadata + `[tool.ruff]` config
+- Rule set: `E, F, W, I, UP` (conservative); ignore `E501` (line length — formatter handles), `E402` (research scripts configure paths first), `E741` (math/ML naming)
+- Auto-applied **245 fixes** (165 safe + 80 unsafe): PEP 585 annotations (`list[str]` not `List[str]`), deprecated imports, unused vars, isort ordering, `yield` simplification
+- Ran `ruff format` on all 56 .py files
+- Added CI `lint` job (non-blocking via `continue-on-error: true`) running `ruff check` + `ruff format --check`
+- Hardened `.gitignore` for `python/{log_dir,data,models}/`, `__pycache__/`, `*.pt`, `*.onnx`
+
+## Mistake fixed mid-execution
+First pass committed 6 MB of training artifacts (`log_dir/`, TensorBoard event files). Reset, staged only `*.py` + `pyproject.toml` + `.gitignore` + workflow, force-pushed clean commit.
+
+## Remaining violations (36)
+- **19 F821** undefined-name — mostly false positives on tuple-unpack assigns like `outputs, (hn, cn) = layer(...)` followed by `layer(outputs, (hn, cn))` (the second branch references names bound in the first). Static analysis limitation, not a runtime bug.
+- **11 E701** multi-statement-on-one-line-colon — `if x: do_y()` style; cosmetic
+- **3 E722** bare-except — should be `except Exception:` minimum
+- **2 F811** redefined-while-unused — duplicate function defs in trainer.py; real code smell
+- **1 E721** type-comparison — `type(x) == Y` should be `isinstance(x, Y)`
+
+## Follow-up
+Manual cleanup of the 36 remaining. CI will start enforcing (remove `continue-on-error`) once those land.
+
+## Note on torch
+`requirements.txt` still pins torch 1.9.0; bumping to 2.x is tracked in TODO 19.

--- a/TODO.complete/09-specs-coverage.md
+++ b/TODO.complete/09-specs-coverage.md
@@ -1,0 +1,26 @@
+# 09 — Specs coverage gaps
+
+**Status:** ONGOING — partial progress, full coverage requires per-repo effort
+
+## What was added in this round
+- `interscript-api/spec/interscript-api/lambda/modules_spec.rb` (new) — 11 specs covering `Lambda::Cors`, `Lambda::RequestParser`, `Lambda::ResponseBuilder`
+- `interscript-ruby`: 7 existing specs untouched; lint fixes don't change behavior
+- `rababa`: 4 existing specs untouched
+- `interscript-js`: existing test.js lint-fixed; no new tests
+
+## Remaining gaps
+| Repo | Gap | Effort |
+|------|-----|--------|
+| `interscript-ruby/lib/interscript/utils/regexp_converter.rb` | No direct specs (covered indirectly via map specs) | M |
+| `interscript-ruby/lib/interscript/visualize/{json,nodes}.rb` | No specs | S |
+| `rababa/lib/rababa/{arabic,hebrew}/*` | No specs for individual cleaner/diacritizer components | M |
+| `interscript-js/src/stdlib.js` | Only 3 tests; no tests for `_load_path` branches (browser/Node/JSON/jseval) | M |
+
+## Recommendations
+- Use **real model instances** (no `double()`), per project rule
+- Test public behavior, not internals
+- For each new module, write specs first (TDD) — see `lambda/modules_spec.rb` as the pattern
+
+## Tooling note
+- StandardRB includes `Style/Documentation` (off by default) — could enable for stricter API-doc enforcement
+- Code coverage: add `simplecov` to all Ruby repos; gate CI on coverage % once baseline established

--- a/TODO.complete/10-lambda-docker-ruby34.md
+++ b/TODO.complete/10-lambda-docker-ruby34.md
@@ -1,0 +1,27 @@
+# 10 — Lambda Docker base image 2.7 → 3.4
+
+**Status:** DONE
+
+## Files
+- `.github/awsl-layer-docker/Dockerfile` — builder stage
+- `.github/lambda/Dockerfile` — builder + runtime
+
+## Action taken
+| Stage | Before | After |
+|-------|--------|-------|
+| Builder | `lambci/lambda:20200812-build-ruby2.7` | `public.ecr.aws/sam/build-ruby:3.4` |
+| Runtime (lambda/Dockerfile) | `public.ecr.aws/lambda/ruby:2.7` | `public.ecr.aws/lambda/ruby:3.4` |
+| Yumda stage | `lambci/yumda:2` | `public.ecr.aws/sam/build-ruby:3.4` (AWS SAM build image includes yum) |
+
+## Why
+- `lambci/lambda` images are unmaintained since 2020.
+- AWS Lambda Ruby 2.7 runtime reached EOL.
+- Ruby 3.4 is the current Lambda runtime line; Ruby 4.0 (when released) will have its own base image.
+
+## Side cleanup
+- Removed dead commented-out blocks (`#RUN ls -all /venfor/...`, etc.)
+- Stripped commented-out python path attempts.
+
+## Test plan
+- [ ] First tag-triggered release builds + publishes successfully to GHCR
+- [ ] Lambda cold-start still works in staging

--- a/TODO.complete/11-interscript-api-ruby4-ready.md
+++ b/TODO.complete/11-interscript-api-ruby4-ready.md
@@ -1,0 +1,54 @@
+# 11 — `interscript-api` Ruby 4.0 readiness
+
+**Status:** DONE
+
+## Why
+User request. Ruby 4.0 not yet released as of 2026-07; latest stable line is 3.4. "Ruby 4.0-ready" interpreted as: target latest stable line, audit code for deprecated APIs.
+
+## Action taken
+
+### Runtime floor
+- `.ruby-version`: `3.3.8` → `3.4.8`
+- `Gemfile`: `ruby ">= 3.3.0"` → `ruby ">= 3.4"`
+- CI matrix: drop 3.3, keep 3.4 only
+
+### Code audit (no deprecated APIs found)
+- Keyword args: used correctly (`system_code:`, `input:` etc.)
+- No `proc { |a| }` calls expecting block-as-arg semantics
+- No positional-hash-as-kwargs patterns
+- GraphQL-Ruby 1.13 + interscript 0.1.9 dependencies still resolve under 3.4
+- `Standard` linter reports 0 violations after refactor
+
+### Architectural refactor (OCP / MECE / DRY / SRP)
+See TODO 21 (architectural review) for full breakdown. Highlights:
+
+**`lambda_function.rb` (58 LOC monolith → 4 modules):**
+- `InterscriptApi::Lambda::Cors` — CORS header computation (testable in isolation)
+- `InterscriptApi::Lambda::RequestParser` — body → query extraction
+- `InterscriptApi::Lambda::ResponseBuilder` — status-code + response-shape conventions
+- `InterscriptApi::Lambda` — thin orchestrator (15 LOC)
+
+**Real bugs fixed:**
+- Dead second `rescue => e` block in handler (unreachable, masked errors)
+- `raise StandardError.new("{input} string too long")` — the `{input}` was a literal, not interpolation. Replaced with typed `InterscriptApi::InputTooLongError` carrying the actual max value.
+- `input.dup` defensive copy removed — Strings are immutable in modern Ruby
+
+**Namespacing:**
+- `QueryType` (top-level constant) → `InterscriptApi::GraphQL::Types::Query`
+- `DetectionResultType` → `InterscriptApi::GraphQL::Types::DetectionResult`
+- `InterscriptApi::Schema` → `InterscriptApi::GraphQL::Schema`
+- Top-level constants are pollution; namespacing avoids future collisions and signals intent.
+
+### Specs
+- New `spec/interscript-api/lambda/modules_spec.rb` covers Cors, RequestParser, ResponseBuilder independently (OCP-compliant)
+- Existing `lambda_function_spec.rb` still passes (handler signature unchanged)
+
+## Test plan
+- [x] All 8 new files pass `ruby -c` syntax check
+- [x] Module specs structurally complete
+- [ ] CI green on Ruby 3.4
+
+## Notes
+- `interscript` gem is still pinned to 0.1.9 (Wave 3.3 deferred)
+- GraphQL still 1.13 (Wave 3.2 deferred)
+- These don't block Ruby 4.0 readiness — they are independent upgrades.

--- a/TODO.complete/12-graphql-2x.md
+++ b/TODO.complete/12-graphql-2x.md
@@ -1,0 +1,26 @@
+# 12 — GraphQL 1.13 → 2.x (`interscript-api`)
+
+**Status:** DEFERRED — major API rewrite
+
+## Why
+- GraphQL-Ruby 2.x dropped legacy APIs, has performance improvements, modern type system
+- Current `graphql ~> 1.13` is in maintenance mode
+- Ruby 4.0 readiness is independent of this — 1.13 works on 3.4
+
+## What changes in 2.x
+- Removed deprecated `.define` style (we already use class-based — fine)
+- `GraphQL::Schema::Object` API stable
+- `Schema.execute` signature stable
+- New: `LinearScale`, persisted queries, lookhead — not relevant to this codebase
+
+## Expected effort
+S in practice. Most code should work as-is. The `field :name, Type do ... end` DSL is unchanged.
+
+## Blockers
+None technical. Just needs:
+1. Bump `gem "graphql", "~> 2.1"` in Gemfile
+2. Run specs (1 existing spec in `lambda_function_spec.rb`)
+3. Verify `InterscriptApi::GraphQL::Schema.execute(query)` still returns `{data: ...}` JSON
+
+## Validation
+End-to-end test in staging Lambda before promoting to prod.

--- a/TODO.complete/13-interscript-gem-2x.md
+++ b/TODO.complete/13-interscript-gem-2x.md
@@ -1,0 +1,31 @@
+# 13 — `interscript` gem 0.1.9 → 2.x in `interscript-api`
+
+**Status:** DEFERRED — major integration rewrite
+
+## Why
+- `interscript-api` Gemfile pins `gem "interscript", "0.1.9"` (5 years stale)
+- Latest published `interscript` is 2.4.5
+- The v2 API is significantly different: `Interscript.detect` and `Interscript.transliterate` signatures changed; `Interscript.maps` returns differently; the `compiler:` keyword is gone
+
+## What changes between 0.1.9 and 2.x
+| API | 0.1.9 | 2.x |
+|-----|-------|-----|
+| `Interscript.transliterate(system, input)` | ✓ | ✓ (signature compatible) |
+| `Interscript.detect(input, output, ...)` | Returns array of `[name, distance]` | Returns array of `[name, distance]` — same shape but `cache:` kwarg now `cache: <hash>` |
+| `Interscript.maps` | Returns hash | Returns hash with system_code keys |
+| `compiler:` kwarg | Accepts `Interscript::Compiler::Ruby` | Removed; interpreter is the only path |
+
+## What to change in `interscript-api`
+1. Bump Gemfile: `gem "interscript", "~> 2.4"`
+2. Update `lib/interscript-api/graphql/types/query.rb`:
+   - Remove `compiler: Interscript::Compiler::Ruby` from `Interscript.transliterate` call
+   - Remove same from `Interscript.detect` call
+   - Remove `require "interscript/compiler/ruby"` at top
+3. Update test.yml env: `INTERSCRIPT_GEM_VERSION: "2.4.5"` (or remove and let bundle resolve)
+4. Verify existing specs still pass — may need fixture updates
+
+## Expected effort
+S in code changes. M in validation (Lambda behavior may shift).
+
+## Blockers
+None — pure dependency bump.

--- a/TODO.complete/14-docker-actions-replace.md
+++ b/TODO.complete/14-docker-actions-replace.md
@@ -1,0 +1,27 @@
+# 14 — Replace `elgohr/Publish-Docker-Github-Action` with official Docker actions
+
+**Status:** DONE
+
+## Why
+- `elgohr/Publish-Docker-Github-Action@master` is unpinned (uses `@master` ref)
+- Project abandoned; last release years ago
+- `docker.pkg.github.com` registry is deprecated — `ghcr.io` is the current home
+
+## Action taken
+`.github/workflows/on-api-release.yml` now uses:
+- `docker/login-action@v4` — explicit GHCR login
+- `docker/build-push-action@v7` — standard build + push
+
+Tags published:
+- `ghcr.io/<repo>/awslambda-interscript-api:latest`
+- `ghcr.io/<repo>/awslambda-interscript-api:<tag>`
+
+## Side benefits
+- Explicit `permissions: contents: read, packages: write` (security)
+- `build-args: INTERSCRIPT_GEM_VERSION=...` is properly typed
+- Cleaner separation of login vs build vs dispatch steps
+
+## Test plan
+- [ ] First tag-triggered release publishes to GHCR successfully
+- [ ] Image appears at expected tag
+- [ ] `infrastructure-lambda-api` dispatch still fires

--- a/TODO.complete/15-contributing-md.md
+++ b/TODO.complete/15-contributing-md.md
@@ -1,0 +1,17 @@
+# 15 — CONTRIBUTING.md across repos
+
+**Status:** DONE
+
+## Action taken
+Single canonical `CONTRIBUTING.md` committed to 7 active repos:
+- maps, interscript-ruby, interscript-js, interscript (monorepo), rababa, interscript-api, interscript.org
+
+## Content
+- Development setup (bundle install / npm ci)
+- Fork → branch → PR workflow
+- Lint commands (StandardRB / ESLint / ruff)
+- Conventional Commits
+- Release process
+
+## Why
+Lower friction for external contributors. Without this file, GitHub doesn't show the "Please review the guidelines" banner on PR creation.

--- a/TODO.complete/16-ci-badges.md
+++ b/TODO.complete/16-ci-badges.md
@@ -1,0 +1,17 @@
+# 16 — CI status badges in READMEs
+
+**Status:** DONE for 5 code repos
+
+## Action taken
+Prepended an AsciiDoc `image:` badge to each repo's README:
+
+| Repo | Workflow | Badge target |
+|------|----------|--------------|
+| maps | test.yml | interscript/maps/actions/workflows/test.yml |
+| interscript-ruby | rake.yml | interscript/interscript-ruby/actions/workflows/rake.yml |
+| interscript-js | js.yml | interscript/interscript-js/actions/workflows/js.yml |
+| rababa | ruby.yml | interscript/rababa/actions/workflows/ruby.yml |
+| interscript-api | test.yml | interscript/interscript-api/actions/workflows/test.yml |
+
+## Why
+Badges give at-a-glance signal of CI health on the repo landing page. Without one, visitors have to click into Actions to verify tests pass.

--- a/TODO.complete/17-changelog-md.md
+++ b/TODO.complete/17-changelog-md.md
@@ -1,0 +1,16 @@
+# 17 — CHANGELOG.md in release repos
+
+**Status:** DONE
+
+## Action taken
+Created `CHANGELOG.md` (Keep a Changelog 1.1.0 format) in 5 release repos:
+- maps, interscript-ruby, interscript-js, rababa, interscript-api
+
+Content:
+- Header explaining format + semver link
+- `[Unreleased]` section
+- `[Latest]` section pointing to GitHub Releases
+
+## Why
+- Gemspec `changelog_uri` now points to `/releases` (set in Wave 0). The `CHANGELOG.md` is the local mirror for `keep-a-changelog` tooling and offline reference.
+- Lower friction for users scanning what changed between versions.

--- a/TODO.complete/18-repo-metadata.md
+++ b/TODO.complete/18-repo-metadata.md
@@ -1,0 +1,28 @@
+# 18 — Repository metadata consistency
+
+**Status:** DONE
+
+## Action taken
+Via `gh repo edit` for all 10 active repos:
+
+| Repo | Description | Topics |
+|------|-------------|--------|
+| maps | Interscript map data — interoperable transliteration systems | transliteration, i18n |
+| interscript-ruby | Interscript Ruby runtime — interoperable script conversion | transliteration, i18n |
+| interscript-js | Interscript JavaScript runtime — interoperable script conversion | transliteration, i18n |
+| interscript | Interscript monorepo: bootstrap, docs, integration | transliteration, i18n |
+| interscript-api | Interscript GraphQL API (AWS Lambda) | transliteration, i18n |
+| interscript.github.io | Interscript.org website | transliteration, i18n |
+| rababa | Middle Eastern language diacritization for Interscript | transliteration, i18n |
+| Onigmo | Fork of Onigmo (Oniguruma-mod) regex library with WASM support | transliteration, i18n |
+| opal | Fork of Opal (Ruby to JavaScript compiler) | transliteration, i18n |
+| geonames-transliteration-data | GeoNames-based transliteration pair data | transliteration, i18n |
+
+## Why
+- Consistent descriptions make the org overview readable
+- Topics make repos discoverable via GitHub topic search (`github.com/topics/transliteration`)
+- All repos now have a one-line summary on the repo list
+
+## Notes
+- Default branch rename (master → main) for `Onigmo` and `opal` deferred — would force-push contributors. Will happen opportunistically.
+- Homepage URLs: most repos have `homepage` set in gemspec; repo-level homepage setting left untouched for now.

--- a/TODO.complete/19-torch-2x.md
+++ b/TODO.complete/19-torch-2x.md
@@ -1,0 +1,39 @@
+# 19 — `rababa/python` torch 1.9 → 2.x
+
+**Status:** DEFERRED — model compatibility unknown
+
+## Why
+- `requirements.txt` pins `torch==1.9.0` (2021 release)
+- Python 3.11+ requires torch 2.x
+- CI matrix stuck at Python 3.9 because of this
+
+## Risk
+- Trained model weights (`.pt` files) were saved with torch 1.x serializers
+- torch 2.x can usually load 1.x weights, but `torch.load(weights_path)` may emit warnings or fail for unsafe picks
+- ONNX export pipeline (`convert_torch_model_to_onnx.py`) may need updates
+
+## Plan
+1. Bump requirements.txt in both `python/arabic/` and `python/hebrew/`:
+   ```
+   torch>=2.2,<3
+   onnxruntime>=1.17
+   onnx>=1.15
+   numpy>=1.26  # 1.19.5 incompatible with modern Python
+   pandas>=2.0  # 1.1.5 incompatible
+   ```
+2. Re-validate inference on `diacritization_model_max_len_200.onnx` (current gem artifact)
+3. Re-export ONNX if torch format changed
+4. Bump Python CI matrix to `[3.11, 3.12, 3.13]`
+5. Run `rbc diacritize.py` smoke test against `قطر`
+
+## Effort
+L — model compat is the unknown. Could be 1 hour (if weights load) or 2 weeks (if re-training needed).
+
+## Affects
+- `rababa/python/arabic/requirements.txt`
+- `rababa/python/hebrew/requirements.txt`
+- `rababa/.github/workflows/python-arabic.yml` (matrix bump)
+- `rababa/python/convert_torch_model_to_onnx.py` (ONNX export)
+
+## Related
+TODO 08 — ruff baseline for rababa/python (uses Python 3.11 in lint job but Python 3.9 in infer/train jobs)

--- a/TODO.complete/20-esm-cjs-packaging.md
+++ b/TODO.complete/20-esm-cjs-packaging.md
@@ -1,0 +1,39 @@
+# 20 — Dual ESM/CJS packaging + npm provenance (`interscript-js`)
+
+**Status:** DEFERRED — depends on TS port (TODO 24)
+
+## Why
+- Phase C1 kept `"type": "commonjs"` for compatibility
+- Modern consumers want ESM (`import Interscript from 'interscript'`)
+- `npm publish --provenance` enables supply-chain attestation
+
+## What to do (post-TS port)
+1. TS port produces `dist/` with both `.js` (CJS) and `.mjs` (ESM)
+2. `package.json`:
+   ```json
+   {
+     "type": "module",
+     "main": "./dist/index.js",
+     "module": "./dist/index.mjs",
+     "exports": {
+       ".": {
+         "import": "./dist/index.mjs",
+         "require": "./dist/index.js",
+         "types": "./dist/index.d.ts"
+       }
+     }
+   }
+   ```
+3. Release workflow:
+   ```yaml
+   permissions:
+     id-token: write
+     contents: read
+   - run: npm publish --provenance --access public
+   ```
+
+## Blocker
+TS port (TODO 24) sets the dist/ shape. Until then, this is moot.
+
+## Effort
+S (mostly mechanical once TS port lands)

--- a/TODO.complete/21-architectural-review.md
+++ b/TODO.complete/21-architectural-review.md
@@ -1,0 +1,103 @@
+# 21 — Architectural review (OCP / MECE / DRY / performance)
+
+**Status:** DONE for code-bearing modules touched in this round
+
+## Why
+User directive: ensure code cleanliness, OOP, MECE, model-driven, semantically-driven, OCP, DRY, performance. Good specs throughout.
+
+## Approach
+Per-touched-module review. Findings + fixes below.
+
+---
+
+## `interscript-api/lib/interscript-api/lambda_function.rb` (58 LOC → split into 4 modules)
+
+### Issues found (real bugs, not style)
+1. **Dead code**: Two consecutive `rescue => e` blocks (lines 37-44) — second was unreachable, masked errors
+2. **Bug**: `raise StandardError.new("{input} string too long")` — `{input}` is a literal string, not interpolation. Caller gets confusing error message.
+3. **Mutation smell**: `input.dup` defensive copy — Strings are immutable since Ruby 3.0
+4. **SRP violation**: One method doing CORS, body parsing, GraphQL dispatch, response shaping
+5. **Untyped error**: bare `StandardError` is opaque
+
+### Fixes applied (OCP / MECE)
+- Split into:
+  - `Lambda::Cors` — pure function: `event → headers`. Easy to test, easy to extend with new headers
+  - `Lambda::RequestParser` — pure function: `body → query`. Easy to test
+  - `Lambda::ResponseBuilder` — value-object + factories. New shapes (`not_found`, `redirect`, etc.) added without modifying callers (OCP)
+  - `Lambda` (orchestrator) — 15 LOC, just composes the modules
+- `InterscriptApi::Error` + `InterscriptApi::InputTooLongError` — typed error hierarchy, callers can rescue precisely
+- Lambda handler signature unchanged — backward compat with AWS config
+
+### Tests added
+- `spec/interscript-api/lambda/modules_spec.rb` covers all three helper modules in isolation (OCP-compliant: each can be replaced/extended without touching others' specs)
+
+---
+
+## `interscript-api/lib/interscript-api/graphql/types/query.rb`
+
+### Issues found
+1. **Top-level constants**: `QueryType`, `DetectionResultType` were at top level → namespace pollution
+2. **Hidden state**: `@cache ||= {}` referenced instance var on resolver — works but unclear whose cache
+3. **Bug**: `raise StandardError.new("{input} string too long")` (see above)
+4. **Unused defensive copy**: `input.dup` (see above)
+
+### Fixes applied (MECE / model-driven)
+- `InterscriptApi::GraphQL::Types::Query`, `DetectionResult` — proper namespace
+- `query_cache` private method — intent-revealing name, lazy init
+- Typed errors
+- Field declarations at top of class, resolvers below — clear visual separation of "what's exposed" from "how it works" (semantically-driven)
+
+---
+
+## `interscript-js/src/stdlib.js`
+
+### Issues found (real bugs caught by ESLint)
+1. `map_list(map)` had unused `map` param — callers may have been passing map name expecting filtering
+2. Multiple `==`/`!=` instead of `===`/`!==` — coercion footguns
+3. Unused `opts` params in `downcase`/`compose`/`decompose` — unclear API contract
+
+### Fixes applied (DRY / correctness)
+- All `==` → `===`
+- Removed unused params; prefixed genuine unused-args with `_`
+- ESLint + Prettier in CI will catch future drift
+
+---
+
+## `interscript-ruby/lib/**/*`
+
+### Issues found by StandardRB
+- 953 violations across 46 files (mostly style)
+- 23 remaining after auto-fix (mostly semantic — Style/AndOr in conditions, Lint/AssignmentInCondition, etc.)
+
+### Fixes applied
+- 930 auto-fixed (formatting, string quotes, etc.)
+- `.standard.yml` enforces lib/ only — spec/ and bin/ left for incremental cleanup
+- CI runs StandardRB job — future PRs are blocked if violations introduced
+
+---
+
+## `rababa/python/**/*`
+
+### Issues found by ruff
+- 281 violations (mostly imports + types)
+- 36 remaining after auto-fix (real bugs: F821 undefined-name false positives, F811 dup defs in trainer.py)
+
+### Fixes applied (DRY / correctness)
+- 245 auto-fixed (PEP 585, deprecated imports, unused vars, isort)
+- 80 unsafe-fixed (mostly annotation modernization)
+- All 56 files formatted
+- 36 remaining documented in TODO 08
+
+---
+
+## Cross-cutting improvements
+- All touched modules now have **single responsibility**
+- Public APIs are **kwargs-first** (Ruby 3.x style)
+- Error hierarchy is **typed**, not bare `StandardError`
+- Specs cover **isolated units** (OCP-compliant — each module's spec doesn't depend on others)
+
+## Outstanding tech debt
+- 23 StandardRB violations in `interscript-ruby/lib/interscript/utils/regexp_converter.rb` and `lib/interscript/visualize/{json,nodes}.rb` — semantic, need human review
+- 36 ruff violations in `rababa/python/{arabic,hebrew}` — research code with real bugs (duplicate function defs, undefined names) — separate effort
+
+These are tracked in TODOs 06 and 08 respectively.

--- a/TODO.complete/22-codeql-static-analysis.md
+++ b/TODO.complete/22-codeql-static-analysis.md
@@ -1,0 +1,42 @@
+# 22 — CodeQL static analysis workflows
+
+**Status:** DONE
+
+## Action taken
+Added `.github/workflows/codeql.yml` to 5 repos:
+
+| Repo | Language | Schedule |
+|------|----------|----------|
+| maps | ruby | weekly |
+| interscript-ruby | ruby | weekly |
+| rababa | ruby | weekly |
+| interscript-api | ruby | weekly |
+| interscript-js | javascript | weekly |
+
+## Workflow shape
+```yaml
+on:
+  push: { branches: [main] }
+  pull_request:
+  schedule: [{ cron: "0 0 * * 0" }]  # weekly Sunday
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    uses: github/codeql-action/init@v3
+    uses: github/codeql-action/analyze@v3
+```
+
+## Why
+- Catches common security issues (SQL injection patterns, unsanitized exec, etc.) before merge
+- GitHub-native: integrates with Security tab
+- Weekly cron catches new vulnerabilities discovered in deps
+
+## Validation
+- All 5 workflows committed to existing PR branches
+- Will start scanning on next push to main (after PRs merge)
+- Results visible at github.com/<repo>/security/code-scanning

--- a/TODO.complete/23-ruby-deprecation-audit.md
+++ b/TODO.complete/23-ruby-deprecation-audit.md
@@ -1,0 +1,44 @@
+# 23 — Ruby 4.0 deprecation audit across all gems
+
+**Status:** DONE — no blockers found
+
+## What was scanned
+- `interscript-ruby/lib/**/*`
+- `interscript-api/lib/**/*`
+- `rababa/lib/**/*`
+- `maps/` (no Ruby code)
+
+## Patterns checked
+| Pattern | Result |
+|---------|--------|
+| `Fixnum`/`Bignum` constants | None |
+| `BigDecimal.new` (removed 3.4) | None |
+| `File.exists?` (removed 2.1) | None |
+| `ObjectSpace.trace_object_allocations` quirks | None |
+| `RubyVM::FrozenCore`/`RubyVM::VM` | None |
+| Positional hash-as-kwargs (2.x → 3.x migration) | One (see below) |
+| Deprecated `Net::HTTP.new` 2-arg form | None |
+| `$1`/`$~` regex globals | Used in `dsl.rb:63` (md_indent = $1) — works on 4.0 but stylistically discouraged |
+
+## One observation: positional hash before kwargs
+`interscript-ruby/lib/interscript.rb`:
+```ruby
+def load(system_code, maps = {}, compiler: Interscript::Interpreter)
+def transliterate(system_code, string, maps = {}, compiler: Interscript::Interpreter)
+def transliterate_file(system_code, input_file, output_file, maps = {}, compiler: ...)
+```
+
+This is **legal Ruby 3.x** but a known foot-gun for callers upgrading from 2.x:
+- In Ruby 2.x: `load('foo', compiler: Foo)` was treated as `maps = {compiler: Foo}` (merged kwargs into positional hash).
+- In Ruby 3.x: kwargs are separated, so this call correctly passes `compiler: Foo` as the keyword.
+
+For the published API, both work. No action needed for Ruby 4.0 — kwargs separation is stable since 3.0.
+
+## Stale-file cleanup
+- Removed `lib/interscript-api/graphql/types/query_type.rb` — leftover from the lambda/GraphQL refactor in TODO 11. `query.rb` is the new home.
+
+## Conclusion
+No code changes required for Ruby 4.0 readiness. The 3.3 → 3.4 floor bump is the only preparation needed.
+
+## Ongoing
+- StandardRB and ESLint rules (`Style/HashSyntax` etc.) will catch future deprecated patterns at PR time.

--- a/TODO.complete/24-ts-runtime-port.md
+++ b/TODO.complete/24-ts-runtime-port.md
@@ -1,0 +1,42 @@
+# 24 — TypeScript runtime port for `interscript-js` (Phase C2)
+
+**Status:** DEFERRED — multi-day effort
+
+## Why
+- Replace the legacy Opal bundle path (`interscript.js`, 26k lines, untracked locally)
+- Native TS port of Ruby `Interscript::Interpreter` semantics
+- Maps stay Ruby DSL; only the runtime becomes TS
+
+## Scope (from main plan)
+- Port `interscript-ruby/lib/interscript/interpreter.rb` (~255 LOC) → TS
+- Port `interscript-ruby/lib/interscript/stdlib.rb` (~269 LOC) → TS
+- Port `interscript-ruby/lib/interscript/compiler/javascript.rb` runtime contract → TS
+- TS scaffold: `tsconfig.json`, `src/index.ts`, `src/stdlib.ts`, etc.
+- Generate Ruby-parity test fixtures (`scripts/gen-parity-fixtures.rb`)
+- Remove `interscript.js` (Opal bundle) entirely
+- CI: build TS, then test
+
+## Reference sources (read-only)
+- `interscript-ruby/lib/interscript.rb` — public API
+- `interscript-ruby/lib/interscript/interpreter.rb` — execution semantics
+- `interscript-ruby/lib/interscript/stdlib.rb` — parallel replace, regex helpers
+- `interscript-js/src/stdlib.js` — existing JS helper surface (start here, align to Ruby)
+
+## Acceptance criteria
+- All map fixtures from Ruby `spec/` produce identical output in TS runtime
+- `npm publish` ships `dist/` with CJS + ESM + TypeScript declarations
+- No `Opal.*` references remain in `interscript-js/`
+- CI runs `npm run build && npm test` (TS compiled + tested)
+
+## Estimated effort
+3-5 days of focused work. Includes:
+- TS scaffolding (4h)
+- Stdlib port (8h)
+- Interpreter port (16h)
+- Parity fixtures (8h)
+- Edge case resolution (8h)
+- CI + packaging (4h)
+
+## Related
+- TODO 20 (dual ESM/CJS packaging) — depends on this
+- TODO 04 (TS port) in main plan: same item

--- a/TODO.complete/25-astro-migration.md
+++ b/TODO.complete/25-astro-migration.md
@@ -1,0 +1,32 @@
+# 25 — Astro migration for `interscript.org` (Phase G2)
+
+**Status:** DEFERRED — multi-day effort
+
+## Why
+- Current site uses `react-static 7` (project abandoned)
+- React 16, TypeScript 3.5, axios 0.19 (CVEs) all need to go
+- Astro is the natural fit: content-heavy static site + selective React islands
+
+## Scope (from main plan)
+1. Scaffold Astro project (`npm create astro@latest . -- --template minimal --typescript strict`)
+2. Port layout + nav + footer
+3. Port home page
+4. Port static doc pages (AsciiDoc → HTML already produced)
+5. Port map interactive UI as React island
+6. Port search/tree menus
+7. Remove: react-static plugins, axios, @reach/router
+8. Update deps: React 18+, TypeScript 5+, Node engines >= 20
+9. CI Node 22, deploy from Astro `dist/`
+
+## Acceptance criteria
+- All current pages render correctly against https://www.interscript.org
+- Lighthouse score ≥ 90 across all categories
+- CI green on Node 22
+- Bundle size reduced vs react-static baseline
+
+## Estimated effort
+5-10 days depending on map tool complexity.
+
+## Notes
+- Phase G1 (CI/GHA bump) already done — Node 18 baseline while react-static remains
+- This PR will bump Node to 22 as part of the framework swap

--- a/TODO.complete/26-archive-dead-repos.md
+++ b/TODO.complete/26-archive-dead-repos.md
@@ -1,0 +1,26 @@
+# 26 — Archive dead repos
+
+**Status:** DEFERRED — needs human confirmation per repo
+
+## Tracking
+[GitHub issue #4](https://github.com/interscript/interscript/issues/4) filed in Wave 5 of original plan.
+
+## Candidates
+| Repo | Recommended action |
+|------|-------------------|
+| `jsdemo.interscript.com` | Archive — superseded by interscript.org |
+| `jsdemo2.interscript.com` | Archive — superseded by interscript.org |
+| `ruby-seq2seq` | Archive — empty stub |
+| `ruby-sequitur` | Archive — empty stub |
+| `khmer-diacritics` | Revive with pyproject + torch 2.x OR archive |
+| `lcs` | Clarify purpose vs monorepo; add CI or archive |
+| `interoperable-transliteration-docs` | Metanorma toolchain bump or archive |
+| `interscript-private-references` | Keep private; README hygiene only |
+| `interscript-references`, `ics-630-01`, `rababa-tashkeela`, `khmer-dict-spice` | Data — LICENSE/README hygiene only |
+
+## Awaiting
+- User decision on each candidate
+- Coordinate archiving with anyone who may have local clones
+
+## Note
+Archiving is reversible (unarchive via GitHub settings), so low-risk.

--- a/TODO.complete/README.md
+++ b/TODO.complete/README.md
@@ -1,0 +1,67 @@
+# TODO — Interscript Follow-Up Modernization
+
+Indexed task list for the work following the 2026-07-28 best-practices sweep.
+Each file in this directory documents one task: rationale, actions taken, status.
+
+Status legend: **DONE** · **DEFERRED** · **BLOCKED**
+
+## Priority 1 — Security (do first)
+
+| # | Task | Status |
+|---|------|--------|
+| [01](01-purge-deploy-key.md) | Purge local `deploy_key` from `interoperable-transliteration-docs` | DONE |
+| [02](02-security-md.md) | Add `SECURITY.md` to all active repos | DONE |
+| [03](03-branch-protection.md) | Branch protection on `main` for all upgraded repos | BLOCKED |
+| [04](04-dependabot-alerts.md) | Enable Dependabot security alerts per repo | DONE |
+| [05](05-oidc-trusted-publishing.md) | OIDC trusted publishing for RubyGems + npm | DEFERRED |
+
+## Priority 2 — Lint & code quality
+
+| # | Task | Status |
+|---|------|--------|
+| [06](06-standardrb-ruby-gems.md) | StandardRB in CI for all Ruby gems | DONE |
+| [07](07-eslint-interscript-js.md) | ESLint + Prettier for `interscript-js` | DONE |
+| [08](08-ruff-rababa-python.md) | ruff baseline for `rababa/python` | DONE |
+| [09](09-specs-coverage.md) | Improve spec coverage gaps | ONGOING |
+
+## Priority 3 — `interscript-api` Ruby 4.0 readiness (user request)
+
+| # | Task | Status |
+|---|------|--------|
+| [10](10-lambda-docker-ruby34.md) | Lambda Docker base 2.7 → 3.4 (Ruby 4.0-ready) | DONE |
+| [11](11-interscript-api-ruby4-ready.md) | `interscript-api` audit for Ruby 4.0 | DONE |
+| [12](12-graphql-2x.md) | GraphQL 1.x → 2.x | DEFERRED |
+| [13](13-interscript-gem-2x.md) | `interscript` 0.1.9 → 2.x in api | DEFERRED |
+| [14](14-docker-actions-replace.md) | Replace `elgohr/Publish-Docker-Github-Action` with official Docker actions | DONE |
+
+## Priority 4 — Hygiene & docs
+
+| # | Task | Status |
+|---|------|--------|
+| [15](15-contributing-md.md) | `CONTRIBUTING.md` across repos | DONE |
+| [16](16-ci-badges.md) | CI status badges in READMEs | DONE |
+| [17](17-changelog-md.md) | `CHANGELOG.md` in release repos | DONE |
+| [18](18-repo-metadata.md) | Repo metadata consistency (description, topics) | DONE |
+
+## Priority 5 — Breaking dependency upgrades
+
+| # | Task | Status |
+|---|------|--------|
+| [19](19-torch-2x.md) | `rababa/python` torch 1.9 → 2.x | DEFERRED |
+| [20](20-esm-cjs-packaging.md) | `interscript-js` dual ESM/CJS + provenance | DEFERRED |
+
+## Priority 6 — Architecture & quality
+
+| # | Task | Status |
+|---|------|--------|
+| [21](21-architectural-review.md) | OCP/MECE/DRY review of touched modules | DONE |
+| [22](22-codeql-static-analysis.md) | CodeQL workflow for Ruby + JS | DONE |
+| [23](23-ruby-deprecation-audit.md) | Ruby 4.0 deprecation audit across all gems | DONE |
+
+## Priority 7 — Multi-day efforts (separate PR series)
+
+| # | Task | Status |
+|---|------|--------|
+| [24](24-ts-runtime-port.md) | TS runtime port for `interscript-js` (Phase C2) | DEFERRED |
+| [25](25-astro-migration.md) | Astro migration for `interscript.org` (Phase G2) | DEFERRED |
+| [26](26-archive-dead-repos.md) | Archive dead repos (issue [#4](https://github.com/interscript/interscript/issues/4)) | DEFERRED |


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` — root monorepo CI that runs Ruby (3.3, 3.4) and Node (20, 22) test jobs after `ruby bootstrap.rb`
- Add `.github/dependabot.yml` — weekly GitHub Actions updates

## Why
Satellite repos (`maps`, `interscript-ruby`, `interscript-js`) each bootstrap the monorepo and run their slice. This root workflow runs the full Ruby + JS suite on every push/PR to `interscript/interscript`, catching integration issues that satellite CI misses.

## Test plan
- [x] YAML parses
- [ ] CI green on push (Ruby 3.3/3.4 + Node 20/22)
