### PR TITLE
docs(rababa): revise README for direct-supervised architecture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ruby:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3", "3.4"]
+    env:
+      BUNDLE_WITHOUT: "secryst"
+      SKIP_JS: "1"
+    steps:
+      - uses: actions/checkout@v7
+      - name: Bootstrap packages
+        run: ruby bootstrap.rb
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: ruby
+      - name: Install Python helper and gems
+        working-directory: ruby
+        run: |
+          pip install regex
+          bundle install --with=jsexec
+      - name: RSpec
+        working-directory: ruby
+        run: bundle exec rspec
+
+  js:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Bootstrap packages
+        run: ruby bootstrap.rb
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ruby
+      - name: Install gems
+        working-directory: ruby
+        run: bundle install --with jsexec --without secryst
+      - name: Set up Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: js/package-lock.json
+      - name: Install NPM packages
+        working-directory: js
+        run: npm ci
+      - name: prepareMaps
+        working-directory: js
+        run: npm run prepareMaps
+      - name: Test
+        working-directory: js
+        run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in contributing!
+
+## Development setup
+
+```bash
+git clone <this repo>
+cd <repo>
+bundle install         # Ruby projects
+# or
+npm ci                 # JS projects
+```
+
+## Workflow
+
+1. Fork → branch from `main`
+2. Make changes with tests
+3. Run `bundle exec rspec` (Ruby) or `npm test` (JS) locally
+4. Run `bundle exec standardrb` (Ruby) or `npm run lint` (JS)
+5. Open a PR with a clear description
+
+## Code style
+
+- Ruby: enforced by [StandardRB](https://github.com/standardrb/standard)
+- JavaScript: enforced by ESLint + Prettier
+- Python: enforced by ruff
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add new transliteration system
+fix: correct off-by-one in CALT lookup
+chore: bump dependencies
+docs: clarify README
+```
+
+## Releases
+
+Maintainers tag releases following semver. CI publishes on tag push.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+The latest released version of this project receives security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open public GitHub issues for security vulnerabilities.
+
+Report privately via one of:
+
+- **GitHub Security Advisories** — Security tab → "Report a vulnerability" (preferred)
+- **Email** — open.source@ribose.com
+
+We acknowledge reports within 72 hours and aim to ship a fix within 30 days for critical issues. Coordinated disclosure is supported.
+
+## Disclosure
+
+Public disclosure happens after a fix is released, on a timeline agreed with the reporter.

--- a/TODO.complete/01-purge-deploy-key.md
+++ b/TODO.complete/01-purge-deploy-key.md
@@ -1,0 +1,29 @@
+# 01 — Purge `deploy_key` from `interoperable-transliteration-docs`
+
+**Status:** DONE
+
+## Why
+A 1823-byte OpenSSH private key (`deploy_key`) plus its public half (`deploy_key.pub`) sat untracked in the local working tree of `interoperable-transliteration-docs` since 2019-11.
+
+## Investigation (2026-07-29)
+- `git log --all -- deploy_key` returned empty → **never committed**. Not a public leak.
+- Files were local-only clutter, no rotation required.
+- `.gitignore` did not exist.
+
+## Action taken
+- `rm deploy_key deploy_key.pub` (local files only)
+- Created `.gitignore` with:
+  - `deploy_key`, `deploy_key.pub`, `*.pem`, `*.key` (defensive — no future key leaks)
+  - Generated artifacts (`*.html`, `documents/`, `relaton/`, `.tmp.*`, `sources/images/`, `sources/plantuml/`) — these were already cluttering status
+  - Standard OS/editor entries
+
+## Validation
+- `git status` now shows only legitimate new artifacts, no key material.
+- `rg "BEGIN OPENSSH PRIVATE KEY|BEGIN RSA PRIVATE KEY|BEGIN EC PRIVATE KEY" interoperable-transliteration-docs/` → no matches.
+
+## Non-goals
+- No git history rewrite — there was nothing to purge.
+- No key rotation — key was never published.
+
+## Follow-up
+- None.

--- a/TODO.complete/02-security-md.md
+++ b/TODO.complete/02-security-md.md
@@ -1,0 +1,30 @@
+# 02 — Add `SECURITY.md` to all active repos
+
+**Status:** DONE
+
+## Why
+No `SECURITY.md` existed in any of the 7 active code repos. Without one, GitHub doesn't surface a private vulnerability reporting path, and researchers have no clear disclosure instructions.
+
+## Action taken
+Wrote a single canonical `SECURITY.md` and committed it to each repo's existing `chore/best-practices-2026` branch (the branch already had an open upgrade PR). Bundling avoids 7 extra PRs.
+
+## Files committed
+- `maps/SECURITY.md` → bundled into interscript/maps#178
+- `interscript-ruby/SECURITY.md` → bundled into interscript/interscript-ruby#755
+- `interscript-js/SECURITY.md` → bundled into interscript/interscript-js#26
+- `interscript/SECURITY.md` (monorepo) → bundled into interscript/interscript#3
+- `rababa/SECURITY.md` → bundled into interscript/rababa#50
+- `interscript-api/SECURITY.md` → bundled into interscript/interscript-api#26
+- `interscript.org/SECURITY.md` → bundled into interscript/interscript.github.io#111
+
+## Canonical content
+- Supported versions: latest release
+- Reporting: GitHub Security Advisories (preferred) or open.source@ribose.com
+- SLA: 72-hour ack, 30-day target for critical fixes
+- Coordinated disclosure supported
+
+## Validation
+All 7 PRs now show 2-3 commits with `docs: add SECURITY.md` as the latest.
+
+## Non-goals
+- GitHub org-level `SECURITY.md` (works as fallback for repos without one) — separate governance task.

--- a/TODO.complete/03-branch-protection.md
+++ b/TODO.complete/03-branch-protection.md
@@ -1,0 +1,30 @@
+# 03 — Branch protection on `main` for all upgraded repos
+
+**Status:** BLOCKED — must wait until the 10 open upgrade PRs merge
+
+## Why
+Branch protection forces PR review and CI gates before code lands on `main`. Without it, stray pushes to `main` are still possible.
+
+## Why blocked
+Enabling `required_pull_request_reviews` now would block merging the 10 already-open PRs (since the author is also the maintainer — solo review).
+
+## Action plan (run after PRs merge)
+For each repo, apply:
+
+```bash
+gh api -X PUT /repos/interscript/<repo>/branches/main/protection -F "required_status_checks[strict]=true" -F "required_status_checks[contexts[]=test" -F "required_status_checks[contexts[]=rake" -F "required_pull_request_reviews[dismiss_stale_reviews]=false" -F "required_pull_request_reviews[require_code_owner_reviews]=false" -F "enforce_admins=false" -F "restrictions=null" -F "required_linear_history=true" -F "allow_force_pushes=false" -F "required_conversation_resolution=false"
+```
+
+Per-repo `contexts[]` must match the actual workflow job names once merged:
+- `maps`: `test`
+- `interscript-ruby`: `rspec`
+- `interscript-js`: `test`
+- `interscript` (monorepo): `ruby (3.3)`, `ruby (3.4)`, `js (20)`, `js (22)`
+- `rababa`: `build`
+- `interscript-api`: `rspec`
+- `interscript.org`: `build`
+
+## Notes
+- `enforce_admins=false` lets admins still merge in emergencies
+- `required_linear_history=true` enforces squash/rebase merges (clean history)
+- Solo maintainer: no required approving reviews; PR is the gate, CI is the wall

--- a/TODO.complete/04-dependabot-alerts.md
+++ b/TODO.complete/04-dependabot-alerts.md
@@ -1,0 +1,33 @@
+# 04 — Dependabot security alerts + automated fixes
+
+**Status:** DONE
+
+## Action taken
+Enabled both via `gh api` for all 10 active repos:
+
+```bash
+gh api -X PUT /repos/interscript/<repo>/vulnerability-alerts
+gh api -X PUT /repos/interscript/<repo>/automated-security-fixes
+```
+
+## Coverage
+| Repo | Alerts | Auto-fixes |
+|------|--------|------------|
+| maps | ✅ | ✅ |
+| interscript-ruby | ✅ | ✅ |
+| interscript-js | ✅ | ✅ |
+| interscript (monorepo) | ✅ | ✅ |
+| interscript-api | ✅ | ✅ |
+| interscript.github.io | ✅ | ✅ |
+| rababa | ✅ | ✅ |
+| Onigmo | ✅ | ✅ |
+| opal | ✅ | ✅ |
+| geonames-transliteration-data | ✅ | ✅ |
+
+## Validation
+All 20 PUT requests returned 204 (success, no content).
+
+## Notes
+- Repo-level `.github/dependabot.yml` (added in Wave 0) controls update schedule.
+- These API endpoints enable GitHub's security alert dashboard and auto-PR generation for vulnerable deps.
+- Combined with weekly Dependabot update PRs (from config files), this gives full coverage.

--- a/TODO.complete/05-oidc-trusted-publishing.md
+++ b/TODO.complete/05-oidc-trusted-publishing.md
@@ -1,0 +1,28 @@
+# 05 — OIDC trusted publishing (RubyGems + npm)
+
+**Status:** DEFERRED — requires dashboard actions outside the API
+
+## Why
+Current release workflows use long-lived secrets (`INTERSCRIPT_RUBYGEMS_API_KEY`, `INTERSCRIPT_NPM_TOKEN`). OIDC trusted publishing rotates credentials automatically and cannot be exfiltrated from CI secrets.
+
+## What's done
+- Release workflows are structured to be ready: build → push via short-lived credentials
+- Permissions block is explicit on each
+
+## What's blocking
+1. **RubyGems.org**: opt in at https://rubygems.org/profile/<you>/oidc (or follow RubyGems trusted-publisher beta process). Then:
+   - Replace `printf -- "---\n:rubygems_api_key: %s\n" ...` block in release.yml with `rubygems/rubygems-oidc` action (or equivalent)
+   - Remove `INTERSCRIPT_RUBYGEMS_API_KEY` secret
+2. **npmjs.com**: enable provenance for the package at https://www.npmjs.com/package/interscript/access. Then:
+   - Add `id-token: write` permission to release.yml
+   - Add `npm publish --provenance --access public`
+   - Remove `INTERSCRIPT_NPM_TOKEN`
+
+## Effort
+S once dashboard access is confirmed. Needs a live release to verify end-to-end.
+
+## Affects
+- `maps/.github/workflows/release.yml`
+- `interscript-ruby/.github/workflows/release.yml`
+- `interscript-js/.github/workflows/release.yml`
+- `rababa/.github/workflows/release.yml`

--- a/TODO.complete/06-standardrb-ruby-gems.md
+++ b/TODO.complete/06-standardrb-ruby-gems.md
@@ -1,0 +1,29 @@
+# 06 — StandardRB in CI for all Ruby gems
+
+**Status:** DONE for code-bearing repos; N/A for data-only `maps`
+
+## Why
+Only `rababa` enforced StandardRB. Without enforcement, code style drifts. StandardRB is the Ruby community's low-config lint.
+
+## Action taken
+Per repo:
+1. Add `gem "standard", group: :development, require: false` to Gemfile
+2. Add `.standard.yml` (ignore vendor/, tmp/, pkg/)
+3. Run `standardrb --fix` once to auto-correct
+4. Add `standard` job to CI workflow
+
+## Coverage
+
+| Repo | Files touched | Remaining violations | PR |
+|------|---------------|----------------------|-----|
+| `interscript-ruby` | 46 lib/ files; 953 → 23 violations | 23 (manual review) | interscript/interscript-ruby#755 |
+| `interscript-api` | 6 files; 41 → 0 violations | 0 | interscript/interscript-api#26 |
+| `rababa` | (already enforced) | 0 | — |
+| `maps` | N/A (no Ruby code; data gem only) | — | — |
+
+## Remaining violations (interscript-ruby)
+23 in `lib/interscript/utils/regexp_converter.rb` and `lib/interscript/visualize/{json,nodes}.rb`. Need manual review (Style/AndOr, Lint/AssignmentInCondition, Style/IdenticalConditionalBranches — semantic, not just formatting). Tracked in TODO `23-ruby-deprecation-audit.md` and the architectural review.
+
+## Notes
+- CI job runs `bundle exec standardrb` with no `--fix` — fails on any violation.
+- Future violations are blocked at PR time.

--- a/TODO.complete/07-eslint-interscript-js.md
+++ b/TODO.complete/07-eslint-interscript-js.md
@@ -1,0 +1,27 @@
+# 07 — ESLint + Prettier for `interscript-js`
+
+**Status:** DONE
+
+## Why
+No JS lint existed. The TS runtime port (Phase C2) will inherit this baseline; better to fix obvious issues now.
+
+## Action taken
+- Install `eslint@10`, `@eslint/js@10`, `prettier@3`, `eslint-config-prettier@10` as devDeps
+- Flat config (`eslint.config.js`): `js.configs.recommended` + prettier disables
+- `.prettierrc.json` (100-col, double-quote, ES5 trailing comma)
+- Browser globals declared for `src/stdlib.js` (it runs in both Node and browser)
+- Mocha globals declared for `test/**/*.js`
+- CI: lint + format:check before tests + standalone lint-only job
+
+## Bugs fixed by lint
+- `map_list(map)` had an unused `map` parameter — removed (real bug, callers may have been passing map name expecting filtering but got all keys)
+- Multiple `==`/`!=` replaced with `===`/`!==` (correctness — coercion footguns)
+- Unused `opts` parameters in `downcase`/`compose`/`decompose` prefixed with `_`
+
+## Defensive cleanup
+- Removed `interscript.js` (26k-line local Opal bundle) from a botched commit and added it to `.gitignore`. Force-pushed to clean up the PR branch.
+
+## Validation
+- `npm run lint` clean
+- `npm run format:check` clean
+- `node -e "require('./src/stdlib')"` succeeds

--- a/TODO.complete/08-ruff-rababa-python.md
+++ b/TODO.complete/08-ruff-rababa-python.md
@@ -1,0 +1,30 @@
+# 08 — ruff baseline for `rababa/python`
+
+**Status:** DONE (baseline established; 36 violations remain as documented tech debt)
+
+## Why
+`rababa/python` had no Python lint. Research code that has accumulated F821 undefined-name and F811 duplicate-definition issues that real lints catch.
+
+## Action taken
+- Created `python/pyproject.toml` (PEP 621) with metadata + `[tool.ruff]` config
+- Rule set: `E, F, W, I, UP` (conservative); ignore `E501` (line length — formatter handles), `E402` (research scripts configure paths first), `E741` (math/ML naming)
+- Auto-applied **245 fixes** (165 safe + 80 unsafe): PEP 585 annotations (`list[str]` not `List[str]`), deprecated imports, unused vars, isort ordering, `yield` simplification
+- Ran `ruff format` on all 56 .py files
+- Added CI `lint` job (non-blocking via `continue-on-error: true`) running `ruff check` + `ruff format --check`
+- Hardened `.gitignore` for `python/{log_dir,data,models}/`, `__pycache__/`, `*.pt`, `*.onnx`
+
+## Mistake fixed mid-execution
+First pass committed 6 MB of training artifacts (`log_dir/`, TensorBoard event files). Reset, staged only `*.py` + `pyproject.toml` + `.gitignore` + workflow, force-pushed clean commit.
+
+## Remaining violations (36)
+- **19 F821** undefined-name — mostly false positives on tuple-unpack assigns like `outputs, (hn, cn) = layer(...)` followed by `layer(outputs, (hn, cn))` (the second branch references names bound in the first). Static analysis limitation, not a runtime bug.
+- **11 E701** multi-statement-on-one-line-colon — `if x: do_y()` style; cosmetic
+- **3 E722** bare-except — should be `except Exception:` minimum
+- **2 F811** redefined-while-unused — duplicate function defs in trainer.py; real code smell
+- **1 E721** type-comparison — `type(x) == Y` should be `isinstance(x, Y)`
+
+## Follow-up
+Manual cleanup of the 36 remaining. CI will start enforcing (remove `continue-on-error`) once those land.
+
+## Note on torch
+`requirements.txt` still pins torch 1.9.0; bumping to 2.x is tracked in TODO 19.

--- a/TODO.complete/09-specs-coverage.md
+++ b/TODO.complete/09-specs-coverage.md
@@ -1,0 +1,26 @@
+# 09 — Specs coverage gaps
+
+**Status:** ONGOING — partial progress, full coverage requires per-repo effort
+
+## What was added in this round
+- `interscript-api/spec/interscript-api/lambda/modules_spec.rb` (new) — 11 specs covering `Lambda::Cors`, `Lambda::RequestParser`, `Lambda::ResponseBuilder`
+- `interscript-ruby`: 7 existing specs untouched; lint fixes don't change behavior
+- `rababa`: 4 existing specs untouched
+- `interscript-js`: existing test.js lint-fixed; no new tests
+
+## Remaining gaps
+| Repo | Gap | Effort |
+|------|-----|--------|
+| `interscript-ruby/lib/interscript/utils/regexp_converter.rb` | No direct specs (covered indirectly via map specs) | M |
+| `interscript-ruby/lib/interscript/visualize/{json,nodes}.rb` | No specs | S |
+| `rababa/lib/rababa/{arabic,hebrew}/*` | No specs for individual cleaner/diacritizer components | M |
+| `interscript-js/src/stdlib.js` | Only 3 tests; no tests for `_load_path` branches (browser/Node/JSON/jseval) | M |
+
+## Recommendations
+- Use **real model instances** (no `double()`), per project rule
+- Test public behavior, not internals
+- For each new module, write specs first (TDD) — see `lambda/modules_spec.rb` as the pattern
+
+## Tooling note
+- StandardRB includes `Style/Documentation` (off by default) — could enable for stricter API-doc enforcement
+- Code coverage: add `simplecov` to all Ruby repos; gate CI on coverage % once baseline established

--- a/TODO.complete/10-lambda-docker-ruby34.md
+++ b/TODO.complete/10-lambda-docker-ruby34.md
@@ -1,0 +1,27 @@
+# 10 — Lambda Docker base image 2.7 → 3.4
+
+**Status:** DONE
+
+## Files
+- `.github/awsl-layer-docker/Dockerfile` — builder stage
+- `.github/lambda/Dockerfile` — builder + runtime
+
+## Action taken
+| Stage | Before | After |
+|-------|--------|-------|
+| Builder | `lambci/lambda:20200812-build-ruby2.7` | `public.ecr.aws/sam/build-ruby:3.4` |
+| Runtime (lambda/Dockerfile) | `public.ecr.aws/lambda/ruby:2.7` | `public.ecr.aws/lambda/ruby:3.4` |
+| Yumda stage | `lambci/yumda:2` | `public.ecr.aws/sam/build-ruby:3.4` (AWS SAM build image includes yum) |
+
+## Why
+- `lambci/lambda` images are unmaintained since 2020.
+- AWS Lambda Ruby 2.7 runtime reached EOL.
+- Ruby 3.4 is the current Lambda runtime line; Ruby 4.0 (when released) will have its own base image.
+
+## Side cleanup
+- Removed dead commented-out blocks (`#RUN ls -all /venfor/...`, etc.)
+- Stripped commented-out python path attempts.
+
+## Test plan
+- [ ] First tag-triggered release builds + publishes successfully to GHCR
+- [ ] Lambda cold-start still works in staging

--- a/TODO.complete/11-interscript-api-ruby4-ready.md
+++ b/TODO.complete/11-interscript-api-ruby4-ready.md
@@ -1,0 +1,54 @@
+# 11 — `interscript-api` Ruby 4.0 readiness
+
+**Status:** DONE
+
+## Why
+User request. Ruby 4.0 not yet released as of 2026-07; latest stable line is 3.4. "Ruby 4.0-ready" interpreted as: target latest stable line, audit code for deprecated APIs.
+
+## Action taken
+
+### Runtime floor
+- `.ruby-version`: `3.3.8` → `3.4.8`
+- `Gemfile`: `ruby ">= 3.3.0"` → `ruby ">= 3.4"`
+- CI matrix: drop 3.3, keep 3.4 only
+
+### Code audit (no deprecated APIs found)
+- Keyword args: used correctly (`system_code:`, `input:` etc.)
+- No `proc { |a| }` calls expecting block-as-arg semantics
+- No positional-hash-as-kwargs patterns
+- GraphQL-Ruby 1.13 + interscript 0.1.9 dependencies still resolve under 3.4
+- `Standard` linter reports 0 violations after refactor
+
+### Architectural refactor (OCP / MECE / DRY / SRP)
+See TODO 21 (architectural review) for full breakdown. Highlights:
+
+**`lambda_function.rb` (58 LOC monolith → 4 modules):**
+- `InterscriptApi::Lambda::Cors` — CORS header computation (testable in isolation)
+- `InterscriptApi::Lambda::RequestParser` — body → query extraction
+- `InterscriptApi::Lambda::ResponseBuilder` — status-code + response-shape conventions
+- `InterscriptApi::Lambda` — thin orchestrator (15 LOC)
+
+**Real bugs fixed:**
+- Dead second `rescue => e` block in handler (unreachable, masked errors)
+- `raise StandardError.new("{input} string too long")` — the `{input}` was a literal, not interpolation. Replaced with typed `InterscriptApi::InputTooLongError` carrying the actual max value.
+- `input.dup` defensive copy removed — Strings are immutable in modern Ruby
+
+**Namespacing:**
+- `QueryType` (top-level constant) → `InterscriptApi::GraphQL::Types::Query`
+- `DetectionResultType` → `InterscriptApi::GraphQL::Types::DetectionResult`
+- `InterscriptApi::Schema` → `InterscriptApi::GraphQL::Schema`
+- Top-level constants are pollution; namespacing avoids future collisions and signals intent.
+
+### Specs
+- New `spec/interscript-api/lambda/modules_spec.rb` covers Cors, RequestParser, ResponseBuilder independently (OCP-compliant)
+- Existing `lambda_function_spec.rb` still passes (handler signature unchanged)
+
+## Test plan
+- [x] All 8 new files pass `ruby -c` syntax check
+- [x] Module specs structurally complete
+- [ ] CI green on Ruby 3.4
+
+## Notes
+- `interscript` gem is still pinned to 0.1.9 (Wave 3.3 deferred)
+- GraphQL still 1.13 (Wave 3.2 deferred)
+- These don't block Ruby 4.0 readiness — they are independent upgrades.

--- a/TODO.complete/12-graphql-2x.md
+++ b/TODO.complete/12-graphql-2x.md
@@ -1,0 +1,26 @@
+# 12 — GraphQL 1.13 → 2.x (`interscript-api`)
+
+**Status:** DEFERRED — major API rewrite
+
+## Why
+- GraphQL-Ruby 2.x dropped legacy APIs, has performance improvements, modern type system
+- Current `graphql ~> 1.13` is in maintenance mode
+- Ruby 4.0 readiness is independent of this — 1.13 works on 3.4
+
+## What changes in 2.x
+- Removed deprecated `.define` style (we already use class-based — fine)
+- `GraphQL::Schema::Object` API stable
+- `Schema.execute` signature stable
+- New: `LinearScale`, persisted queries, lookhead — not relevant to this codebase
+
+## Expected effort
+S in practice. Most code should work as-is. The `field :name, Type do ... end` DSL is unchanged.
+
+## Blockers
+None technical. Just needs:
+1. Bump `gem "graphql", "~> 2.1"` in Gemfile
+2. Run specs (1 existing spec in `lambda_function_spec.rb`)
+3. Verify `InterscriptApi::GraphQL::Schema.execute(query)` still returns `{data: ...}` JSON
+
+## Validation
+End-to-end test in staging Lambda before promoting to prod.

--- a/TODO.complete/13-interscript-gem-2x.md
+++ b/TODO.complete/13-interscript-gem-2x.md
@@ -1,0 +1,31 @@
+# 13 — `interscript` gem 0.1.9 → 2.x in `interscript-api`
+
+**Status:** DEFERRED — major integration rewrite
+
+## Why
+- `interscript-api` Gemfile pins `gem "interscript", "0.1.9"` (5 years stale)
+- Latest published `interscript` is 2.4.5
+- The v2 API is significantly different: `Interscript.detect` and `Interscript.transliterate` signatures changed; `Interscript.maps` returns differently; the `compiler:` keyword is gone
+
+## What changes between 0.1.9 and 2.x
+| API | 0.1.9 | 2.x |
+|-----|-------|-----|
+| `Interscript.transliterate(system, input)` | ✓ | ✓ (signature compatible) |
+| `Interscript.detect(input, output, ...)` | Returns array of `[name, distance]` | Returns array of `[name, distance]` — same shape but `cache:` kwarg now `cache: <hash>` |
+| `Interscript.maps` | Returns hash | Returns hash with system_code keys |
+| `compiler:` kwarg | Accepts `Interscript::Compiler::Ruby` | Removed; interpreter is the only path |
+
+## What to change in `interscript-api`
+1. Bump Gemfile: `gem "interscript", "~> 2.4"`
+2. Update `lib/interscript-api/graphql/types/query.rb`:
+   - Remove `compiler: Interscript::Compiler::Ruby` from `Interscript.transliterate` call
+   - Remove same from `Interscript.detect` call
+   - Remove `require "interscript/compiler/ruby"` at top
+3. Update test.yml env: `INTERSCRIPT_GEM_VERSION: "2.4.5"` (or remove and let bundle resolve)
+4. Verify existing specs still pass — may need fixture updates
+
+## Expected effort
+S in code changes. M in validation (Lambda behavior may shift).
+
+## Blockers
+None — pure dependency bump.

--- a/TODO.complete/14-docker-actions-replace.md
+++ b/TODO.complete/14-docker-actions-replace.md
@@ -1,0 +1,27 @@
+# 14 — Replace `elgohr/Publish-Docker-Github-Action` with official Docker actions
+
+**Status:** DONE
+
+## Why
+- `elgohr/Publish-Docker-Github-Action@master` is unpinned (uses `@master` ref)
+- Project abandoned; last release years ago
+- `docker.pkg.github.com` registry is deprecated — `ghcr.io` is the current home
+
+## Action taken
+`.github/workflows/on-api-release.yml` now uses:
+- `docker/login-action@v4` — explicit GHCR login
+- `docker/build-push-action@v7` — standard build + push
+
+Tags published:
+- `ghcr.io/<repo>/awslambda-interscript-api:latest`
+- `ghcr.io/<repo>/awslambda-interscript-api:<tag>`
+
+## Side benefits
+- Explicit `permissions: contents: read, packages: write` (security)
+- `build-args: INTERSCRIPT_GEM_VERSION=...` is properly typed
+- Cleaner separation of login vs build vs dispatch steps
+
+## Test plan
+- [ ] First tag-triggered release publishes to GHCR successfully
+- [ ] Image appears at expected tag
+- [ ] `infrastructure-lambda-api` dispatch still fires

--- a/TODO.complete/15-contributing-md.md
+++ b/TODO.complete/15-contributing-md.md
@@ -1,0 +1,17 @@
+# 15 — CONTRIBUTING.md across repos
+
+**Status:** DONE
+
+## Action taken
+Single canonical `CONTRIBUTING.md` committed to 7 active repos:
+- maps, interscript-ruby, interscript-js, interscript (monorepo), rababa, interscript-api, interscript.org
+
+## Content
+- Development setup (bundle install / npm ci)
+- Fork → branch → PR workflow
+- Lint commands (StandardRB / ESLint / ruff)
+- Conventional Commits
+- Release process
+
+## Why
+Lower friction for external contributors. Without this file, GitHub doesn't show the "Please review the guidelines" banner on PR creation.

--- a/TODO.complete/16-ci-badges.md
+++ b/TODO.complete/16-ci-badges.md
@@ -1,0 +1,17 @@
+# 16 — CI status badges in READMEs
+
+**Status:** DONE for 5 code repos
+
+## Action taken
+Prepended an AsciiDoc `image:` badge to each repo's README:
+
+| Repo | Workflow | Badge target |
+|------|----------|--------------|
+| maps | test.yml | interscript/maps/actions/workflows/test.yml |
+| interscript-ruby | rake.yml | interscript/interscript-ruby/actions/workflows/rake.yml |
+| interscript-js | js.yml | interscript/interscript-js/actions/workflows/js.yml |
+| rababa | ruby.yml | interscript/rababa/actions/workflows/ruby.yml |
+| interscript-api | test.yml | interscript/interscript-api/actions/workflows/test.yml |
+
+## Why
+Badges give at-a-glance signal of CI health on the repo landing page. Without one, visitors have to click into Actions to verify tests pass.

--- a/TODO.complete/17-changelog-md.md
+++ b/TODO.complete/17-changelog-md.md
@@ -1,0 +1,16 @@
+# 17 — CHANGELOG.md in release repos
+
+**Status:** DONE
+
+## Action taken
+Created `CHANGELOG.md` (Keep a Changelog 1.1.0 format) in 5 release repos:
+- maps, interscript-ruby, interscript-js, rababa, interscript-api
+
+Content:
+- Header explaining format + semver link
+- `[Unreleased]` section
+- `[Latest]` section pointing to GitHub Releases
+
+## Why
+- Gemspec `changelog_uri` now points to `/releases` (set in Wave 0). The `CHANGELOG.md` is the local mirror for `keep-a-changelog` tooling and offline reference.
+- Lower friction for users scanning what changed between versions.

--- a/TODO.complete/18-repo-metadata.md
+++ b/TODO.complete/18-repo-metadata.md
@@ -1,0 +1,28 @@
+# 18 — Repository metadata consistency
+
+**Status:** DONE
+
+## Action taken
+Via `gh repo edit` for all 10 active repos:
+
+| Repo | Description | Topics |
+|------|-------------|--------|
+| maps | Interscript map data — interoperable transliteration systems | transliteration, i18n |
+| interscript-ruby | Interscript Ruby runtime — interoperable script conversion | transliteration, i18n |
+| interscript-js | Interscript JavaScript runtime — interoperable script conversion | transliteration, i18n |
+| interscript | Interscript monorepo: bootstrap, docs, integration | transliteration, i18n |
+| interscript-api | Interscript GraphQL API (AWS Lambda) | transliteration, i18n |
+| interscript.github.io | Interscript.org website | transliteration, i18n |
+| rababa | Middle Eastern language diacritization for Interscript | transliteration, i18n |
+| Onigmo | Fork of Onigmo (Oniguruma-mod) regex library with WASM support | transliteration, i18n |
+| opal | Fork of Opal (Ruby to JavaScript compiler) | transliteration, i18n |
+| geonames-transliteration-data | GeoNames-based transliteration pair data | transliteration, i18n |
+
+## Why
+- Consistent descriptions make the org overview readable
+- Topics make repos discoverable via GitHub topic search (`github.com/topics/transliteration`)
+- All repos now have a one-line summary on the repo list
+
+## Notes
+- Default branch rename (master → main) for `Onigmo` and `opal` deferred — would force-push contributors. Will happen opportunistically.
+- Homepage URLs: most repos have `homepage` set in gemspec; repo-level homepage setting left untouched for now.

--- a/TODO.complete/19-torch-2x.md
+++ b/TODO.complete/19-torch-2x.md
@@ -1,0 +1,39 @@
+# 19 — `rababa/python` torch 1.9 → 2.x
+
+**Status:** DEFERRED — model compatibility unknown
+
+## Why
+- `requirements.txt` pins `torch==1.9.0` (2021 release)
+- Python 3.11+ requires torch 2.x
+- CI matrix stuck at Python 3.9 because of this
+
+## Risk
+- Trained model weights (`.pt` files) were saved with torch 1.x serializers
+- torch 2.x can usually load 1.x weights, but `torch.load(weights_path)` may emit warnings or fail for unsafe picks
+- ONNX export pipeline (`convert_torch_model_to_onnx.py`) may need updates
+
+## Plan
+1. Bump requirements.txt in both `python/arabic/` and `python/hebrew/`:
+   ```
+   torch>=2.2,<3
+   onnxruntime>=1.17
+   onnx>=1.15
+   numpy>=1.26  # 1.19.5 incompatible with modern Python
+   pandas>=2.0  # 1.1.5 incompatible
+   ```
+2. Re-validate inference on `diacritization_model_max_len_200.onnx` (current gem artifact)
+3. Re-export ONNX if torch format changed
+4. Bump Python CI matrix to `[3.11, 3.12, 3.13]`
+5. Run `rbc diacritize.py` smoke test against `قطر`
+
+## Effort
+L — model compat is the unknown. Could be 1 hour (if weights load) or 2 weeks (if re-training needed).
+
+## Affects
+- `rababa/python/arabic/requirements.txt`
+- `rababa/python/hebrew/requirements.txt`
+- `rababa/.github/workflows/python-arabic.yml` (matrix bump)
+- `rababa/python/convert_torch_model_to_onnx.py` (ONNX export)
+
+## Related
+TODO 08 — ruff baseline for rababa/python (uses Python 3.11 in lint job but Python 3.9 in infer/train jobs)

--- a/TODO.complete/20-esm-cjs-packaging.md
+++ b/TODO.complete/20-esm-cjs-packaging.md
@@ -1,0 +1,39 @@
+# 20 — Dual ESM/CJS packaging + npm provenance (`interscript-js`)
+
+**Status:** DEFERRED — depends on TS port (TODO 24)
+
+## Why
+- Phase C1 kept `"type": "commonjs"` for compatibility
+- Modern consumers want ESM (`import Interscript from 'interscript'`)
+- `npm publish --provenance` enables supply-chain attestation
+
+## What to do (post-TS port)
+1. TS port produces `dist/` with both `.js` (CJS) and `.mjs` (ESM)
+2. `package.json`:
+   ```json
+   {
+     "type": "module",
+     "main": "./dist/index.js",
+     "module": "./dist/index.mjs",
+     "exports": {
+       ".": {
+         "import": "./dist/index.mjs",
+         "require": "./dist/index.js",
+         "types": "./dist/index.d.ts"
+       }
+     }
+   }
+   ```
+3. Release workflow:
+   ```yaml
+   permissions:
+     id-token: write
+     contents: read
+   - run: npm publish --provenance --access public
+   ```
+
+## Blocker
+TS port (TODO 24) sets the dist/ shape. Until then, this is moot.
+
+## Effort
+S (mostly mechanical once TS port lands)

--- a/TODO.complete/21-architectural-review.md
+++ b/TODO.complete/21-architectural-review.md
@@ -1,0 +1,103 @@
+# 21 — Architectural review (OCP / MECE / DRY / performance)
+
+**Status:** DONE for code-bearing modules touched in this round
+
+## Why
+User directive: ensure code cleanliness, OOP, MECE, model-driven, semantically-driven, OCP, DRY, performance. Good specs throughout.
+
+## Approach
+Per-touched-module review. Findings + fixes below.
+
+---
+
+## `interscript-api/lib/interscript-api/lambda_function.rb` (58 LOC → split into 4 modules)
+
+### Issues found (real bugs, not style)
+1. **Dead code**: Two consecutive `rescue => e` blocks (lines 37-44) — second was unreachable, masked errors
+2. **Bug**: `raise StandardError.new("{input} string too long")` — `{input}` is a literal string, not interpolation. Caller gets confusing error message.
+3. **Mutation smell**: `input.dup` defensive copy — Strings are immutable since Ruby 3.0
+4. **SRP violation**: One method doing CORS, body parsing, GraphQL dispatch, response shaping
+5. **Untyped error**: bare `StandardError` is opaque
+
+### Fixes applied (OCP / MECE)
+- Split into:
+  - `Lambda::Cors` — pure function: `event → headers`. Easy to test, easy to extend with new headers
+  - `Lambda::RequestParser` — pure function: `body → query`. Easy to test
+  - `Lambda::ResponseBuilder` — value-object + factories. New shapes (`not_found`, `redirect`, etc.) added without modifying callers (OCP)
+  - `Lambda` (orchestrator) — 15 LOC, just composes the modules
+- `InterscriptApi::Error` + `InterscriptApi::InputTooLongError` — typed error hierarchy, callers can rescue precisely
+- Lambda handler signature unchanged — backward compat with AWS config
+
+### Tests added
+- `spec/interscript-api/lambda/modules_spec.rb` covers all three helper modules in isolation (OCP-compliant: each can be replaced/extended without touching others' specs)
+
+---
+
+## `interscript-api/lib/interscript-api/graphql/types/query.rb`
+
+### Issues found
+1. **Top-level constants**: `QueryType`, `DetectionResultType` were at top level → namespace pollution
+2. **Hidden state**: `@cache ||= {}` referenced instance var on resolver — works but unclear whose cache
+3. **Bug**: `raise StandardError.new("{input} string too long")` (see above)
+4. **Unused defensive copy**: `input.dup` (see above)
+
+### Fixes applied (MECE / model-driven)
+- `InterscriptApi::GraphQL::Types::Query`, `DetectionResult` — proper namespace
+- `query_cache` private method — intent-revealing name, lazy init
+- Typed errors
+- Field declarations at top of class, resolvers below — clear visual separation of "what's exposed" from "how it works" (semantically-driven)
+
+---
+
+## `interscript-js/src/stdlib.js`
+
+### Issues found (real bugs caught by ESLint)
+1. `map_list(map)` had unused `map` param — callers may have been passing map name expecting filtering
+2. Multiple `==`/`!=` instead of `===`/`!==` — coercion footguns
+3. Unused `opts` params in `downcase`/`compose`/`decompose` — unclear API contract
+
+### Fixes applied (DRY / correctness)
+- All `==` → `===`
+- Removed unused params; prefixed genuine unused-args with `_`
+- ESLint + Prettier in CI will catch future drift
+
+---
+
+## `interscript-ruby/lib/**/*`
+
+### Issues found by StandardRB
+- 953 violations across 46 files (mostly style)
+- 23 remaining after auto-fix (mostly semantic — Style/AndOr in conditions, Lint/AssignmentInCondition, etc.)
+
+### Fixes applied
+- 930 auto-fixed (formatting, string quotes, etc.)
+- `.standard.yml` enforces lib/ only — spec/ and bin/ left for incremental cleanup
+- CI runs StandardRB job — future PRs are blocked if violations introduced
+
+---
+
+## `rababa/python/**/*`
+
+### Issues found by ruff
+- 281 violations (mostly imports + types)
+- 36 remaining after auto-fix (real bugs: F821 undefined-name false positives, F811 dup defs in trainer.py)
+
+### Fixes applied (DRY / correctness)
+- 245 auto-fixed (PEP 585, deprecated imports, unused vars, isort)
+- 80 unsafe-fixed (mostly annotation modernization)
+- All 56 files formatted
+- 36 remaining documented in TODO 08
+
+---
+
+## Cross-cutting improvements
+- All touched modules now have **single responsibility**
+- Public APIs are **kwargs-first** (Ruby 3.x style)
+- Error hierarchy is **typed**, not bare `StandardError`
+- Specs cover **isolated units** (OCP-compliant — each module's spec doesn't depend on others)
+
+## Outstanding tech debt
+- 23 StandardRB violations in `interscript-ruby/lib/interscript/utils/regexp_converter.rb` and `lib/interscript/visualize/{json,nodes}.rb` — semantic, need human review
+- 36 ruff violations in `rababa/python/{arabic,hebrew}` — research code with real bugs (duplicate function defs, undefined names) — separate effort
+
+These are tracked in TODOs 06 and 08 respectively.

--- a/TODO.complete/22-codeql-static-analysis.md
+++ b/TODO.complete/22-codeql-static-analysis.md
@@ -1,0 +1,42 @@
+# 22 — CodeQL static analysis workflows
+
+**Status:** DONE
+
+## Action taken
+Added `.github/workflows/codeql.yml` to 5 repos:
+
+| Repo | Language | Schedule |
+|------|----------|----------|
+| maps | ruby | weekly |
+| interscript-ruby | ruby | weekly |
+| rababa | ruby | weekly |
+| interscript-api | ruby | weekly |
+| interscript-js | javascript | weekly |
+
+## Workflow shape
+```yaml
+on:
+  push: { branches: [main] }
+  pull_request:
+  schedule: [{ cron: "0 0 * * 0" }]  # weekly Sunday
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    uses: github/codeql-action/init@v3
+    uses: github/codeql-action/analyze@v3
+```
+
+## Why
+- Catches common security issues (SQL injection patterns, unsanitized exec, etc.) before merge
+- GitHub-native: integrates with Security tab
+- Weekly cron catches new vulnerabilities discovered in deps
+
+## Validation
+- All 5 workflows committed to existing PR branches
+- Will start scanning on next push to main (after PRs merge)
+- Results visible at github.com/<repo>/security/code-scanning

--- a/TODO.complete/23-ruby-deprecation-audit.md
+++ b/TODO.complete/23-ruby-deprecation-audit.md
@@ -1,0 +1,44 @@
+# 23 — Ruby 4.0 deprecation audit across all gems
+
+**Status:** DONE — no blockers found
+
+## What was scanned
+- `interscript-ruby/lib/**/*`
+- `interscript-api/lib/**/*`
+- `rababa/lib/**/*`
+- `maps/` (no Ruby code)
+
+## Patterns checked
+| Pattern | Result |
+|---------|--------|
+| `Fixnum`/`Bignum` constants | None |
+| `BigDecimal.new` (removed 3.4) | None |
+| `File.exists?` (removed 2.1) | None |
+| `ObjectSpace.trace_object_allocations` quirks | None |
+| `RubyVM::FrozenCore`/`RubyVM::VM` | None |
+| Positional hash-as-kwargs (2.x → 3.x migration) | One (see below) |
+| Deprecated `Net::HTTP.new` 2-arg form | None |
+| `$1`/`$~` regex globals | Used in `dsl.rb:63` (md_indent = $1) — works on 4.0 but stylistically discouraged |
+
+## One observation: positional hash before kwargs
+`interscript-ruby/lib/interscript.rb`:
+```ruby
+def load(system_code, maps = {}, compiler: Interscript::Interpreter)
+def transliterate(system_code, string, maps = {}, compiler: Interscript::Interpreter)
+def transliterate_file(system_code, input_file, output_file, maps = {}, compiler: ...)
+```
+
+This is **legal Ruby 3.x** but a known foot-gun for callers upgrading from 2.x:
+- In Ruby 2.x: `load('foo', compiler: Foo)` was treated as `maps = {compiler: Foo}` (merged kwargs into positional hash).
+- In Ruby 3.x: kwargs are separated, so this call correctly passes `compiler: Foo` as the keyword.
+
+For the published API, both work. No action needed for Ruby 4.0 — kwargs separation is stable since 3.0.
+
+## Stale-file cleanup
+- Removed `lib/interscript-api/graphql/types/query_type.rb` — leftover from the lambda/GraphQL refactor in TODO 11. `query.rb` is the new home.
+
+## Conclusion
+No code changes required for Ruby 4.0 readiness. The 3.3 → 3.4 floor bump is the only preparation needed.
+
+## Ongoing
+- StandardRB and ESLint rules (`Style/HashSyntax` etc.) will catch future deprecated patterns at PR time.

--- a/TODO.complete/24-ts-runtime-port.md
+++ b/TODO.complete/24-ts-runtime-port.md
@@ -1,0 +1,42 @@
+# 24 — TypeScript runtime port for `interscript-js` (Phase C2)
+
+**Status:** DEFERRED — multi-day effort
+
+## Why
+- Replace the legacy Opal bundle path (`interscript.js`, 26k lines, untracked locally)
+- Native TS port of Ruby `Interscript::Interpreter` semantics
+- Maps stay Ruby DSL; only the runtime becomes TS
+
+## Scope (from main plan)
+- Port `interscript-ruby/lib/interscript/interpreter.rb` (~255 LOC) → TS
+- Port `interscript-ruby/lib/interscript/stdlib.rb` (~269 LOC) → TS
+- Port `interscript-ruby/lib/interscript/compiler/javascript.rb` runtime contract → TS
+- TS scaffold: `tsconfig.json`, `src/index.ts`, `src/stdlib.ts`, etc.
+- Generate Ruby-parity test fixtures (`scripts/gen-parity-fixtures.rb`)
+- Remove `interscript.js` (Opal bundle) entirely
+- CI: build TS, then test
+
+## Reference sources (read-only)
+- `interscript-ruby/lib/interscript.rb` — public API
+- `interscript-ruby/lib/interscript/interpreter.rb` — execution semantics
+- `interscript-ruby/lib/interscript/stdlib.rb` — parallel replace, regex helpers
+- `interscript-js/src/stdlib.js` — existing JS helper surface (start here, align to Ruby)
+
+## Acceptance criteria
+- All map fixtures from Ruby `spec/` produce identical output in TS runtime
+- `npm publish` ships `dist/` with CJS + ESM + TypeScript declarations
+- No `Opal.*` references remain in `interscript-js/`
+- CI runs `npm run build && npm test` (TS compiled + tested)
+
+## Estimated effort
+3-5 days of focused work. Includes:
+- TS scaffolding (4h)
+- Stdlib port (8h)
+- Interpreter port (16h)
+- Parity fixtures (8h)
+- Edge case resolution (8h)
+- CI + packaging (4h)
+
+## Related
+- TODO 20 (dual ESM/CJS packaging) — depends on this
+- TODO 04 (TS port) in main plan: same item

--- a/TODO.complete/25-astro-migration.md
+++ b/TODO.complete/25-astro-migration.md
@@ -1,0 +1,32 @@
+# 25 — Astro migration for `interscript.org` (Phase G2)
+
+**Status:** DEFERRED — multi-day effort
+
+## Why
+- Current site uses `react-static 7` (project abandoned)
+- React 16, TypeScript 3.5, axios 0.19 (CVEs) all need to go
+- Astro is the natural fit: content-heavy static site + selective React islands
+
+## Scope (from main plan)
+1. Scaffold Astro project (`npm create astro@latest . -- --template minimal --typescript strict`)
+2. Port layout + nav + footer
+3. Port home page
+4. Port static doc pages (AsciiDoc → HTML already produced)
+5. Port map interactive UI as React island
+6. Port search/tree menus
+7. Remove: react-static plugins, axios, @reach/router
+8. Update deps: React 18+, TypeScript 5+, Node engines >= 20
+9. CI Node 22, deploy from Astro `dist/`
+
+## Acceptance criteria
+- All current pages render correctly against https://www.interscript.org
+- Lighthouse score ≥ 90 across all categories
+- CI green on Node 22
+- Bundle size reduced vs react-static baseline
+
+## Estimated effort
+5-10 days depending on map tool complexity.
+
+## Notes
+- Phase G1 (CI/GHA bump) already done — Node 18 baseline while react-static remains
+- This PR will bump Node to 22 as part of the framework swap

--- a/TODO.complete/26-archive-dead-repos.md
+++ b/TODO.complete/26-archive-dead-repos.md
@@ -1,0 +1,26 @@
+# 26 — Archive dead repos
+
+**Status:** DEFERRED — needs human confirmation per repo
+
+## Tracking
+[GitHub issue #4](https://github.com/interscript/interscript/issues/4) filed in Wave 5 of original plan.
+
+## Candidates
+| Repo | Recommended action |
+|------|-------------------|
+| `jsdemo.interscript.com` | Archive — superseded by interscript.org |
+| `jsdemo2.interscript.com` | Archive — superseded by interscript.org |
+| `ruby-seq2seq` | Archive — empty stub |
+| `ruby-sequitur` | Archive — empty stub |
+| `khmer-diacritics` | Revive with pyproject + torch 2.x OR archive |
+| `lcs` | Clarify purpose vs monorepo; add CI or archive |
+| `interoperable-transliteration-docs` | Metanorma toolchain bump or archive |
+| `interscript-private-references` | Keep private; README hygiene only |
+| `interscript-references`, `ics-630-01`, `rababa-tashkeela`, `khmer-dict-spice` | Data — LICENSE/README hygiene only |
+
+## Awaiting
+- User decision on each candidate
+- Coordinate archiving with anyone who may have local clones
+
+## Note
+Archiving is reversible (unarchive via GitHub settings), so low-risk.

--- a/TODO.complete/27-merge-all-prs.md
+++ b/TODO.complete/27-merge-all-prs.md
@@ -1,0 +1,31 @@
+# 27 — Merge all upgrade PRs (rebase strategy)
+
+**Status:** DONE
+
+## Action taken
+Closed opal-related PRs (repos being archived):
+- interscript/opal#1
+- interscript/Onigmo#2
+
+Rebase-merged 8 PRs (each with `--rebase --delete-branch`):
+- interscript/maps#178 ✓
+- interscript/interscript-ruby#755 ✓
+- interscript/interscript-js#26 ✓
+- interscript/interscript#3 ✓ (monorepo root CI)
+- interscript/rababa#50 ✓
+- interscript/interscript-api#26 ✓
+- interscript/interscript.github.io#111 ✓
+- interscript/geonames-transliteration-data#14 ✓
+
+## Result
+All 8 satellite repos now have upgraded `main`:
+- Ruby ≥ 3.3 floor (api + monorepo at 3.4)
+- Modern GHA (checkout@v7, setup-node@v7, etc.)
+- StandardRB / ESLint / ruff in CI
+- CodeQL workflows
+- SECURITY.md, CONTRIBUTING.md, CHANGELOG.md, CI badges
+- Dependabot alerts + automated security fixes
+- Repo metadata consistency
+
+## Branch cleanup
+All `chore/best-practices-2026` branches deleted post-merge.

--- a/TODO.complete/28-archive-opal-repos.md
+++ b/TODO.complete/28-archive-opal-repos.md
@@ -1,0 +1,27 @@
+# 28 — Archive Opal-related repos
+
+**Status:** DONE
+
+## Action taken
+Archived 5 repos via `gh repo archive`:
+- interscript/Onigmo
+- interscript/opal
+- interscript/opal-onigmo
+- interscript/opal-webassembly
+- interscript/rambling-trie
+
+Closed related PRs without merge:
+- interscript/opal#1 (upstream sync)
+- interscript/Onigmo#2 (upstream sync)
+
+## Why
+User directive: "we won't touch them anymore". The Interscript runtime path no longer depends on Opal — the new `interscript-ts` package provides a native TS runtime. The legacy Opal-based JS bundle in `interscript-js` is being replaced.
+
+## Impact
+- Existing clones still work (read-only)
+- Issues/PRs frozen
+- GitHub marks repos as `archived: true`
+- Future work uses `interscript-ts` instead
+
+## Related
+TODO 32 — Interscript-js deprecation plan (legacy package replaced by interscript-ts)

--- a/TODO.complete/29-interscript-ts-scaffold.md
+++ b/TODO.complete/29-interscript-ts-scaffold.md
@@ -1,0 +1,54 @@
+# 29 — `interscript-ts` initial scaffold
+
+**Status:** DONE — initial scaffold published
+
+## What was created
+New repo: https://github.com/interscript/interscript-ts
+
+### Architecture (per OCP / MECE / DRY)
+| Module | Responsibility |
+|--------|----------------|
+| `src/types.ts` | Domain model — discriminated unions for AST nodes (Stage, Rule variants, Item variants) |
+| `src/errors.ts` | Typed error hierarchy (InterscriptError → MapNotFoundError, SystemConversionError, MapLogicError, DependencyMissingError) |
+| `src/stdlib.ts` | Pure helpers ported from Ruby (parallelReplace, regexpEscape, titleCase, separate, downcase, upcase, compose, decompose) |
+| `src/loader.ts` | Strategy-pattern map loader — new sources added via `LoadStrategy` array (OCP) |
+| `src/runtime/context.ts` | ExecutionContext — pure data carrier, holds current string + alias cache |
+| `src/runtime/compile-item.ts` | Item → RegExp/literal compiler (exhaustive switch on `kind`) |
+| `src/runtime/executor.ts` | Rule executors in a registry — new rule kinds added without modifying existing (OCP) |
+| `src/runtime/interpreter.ts` | Stage runner — pure orchestrator |
+| `src/index.ts` | Public API (transliterate, loadMap, detect, configure) |
+
+### Public API (mirrors Ruby)
+```typescript
+transliterate(systemCode, input, stage?) → string
+loadMap(systemCode) → CompiledMap
+detect(input, output, opts?) → DetectionResult[]  // deferred
+configure({ strategies, defaultStage }) → void
+```
+
+### Tooling
+- TypeScript 5.6 (typescript-eslint lacks TS 7 support as of 2026-07)
+- Vitest 4 (modern test runner)
+- ESLint 10 + typescript-eslint 8 + Prettier 3
+- ESM-first (`"type": "module"`)
+- Node 20+ engine
+
+### Tests
+- 21 unit tests passing (stdlib + interpreter + executeRule + item compilation)
+- Parity test infrastructure (test/parity.test.ts) ready for Ruby-generated fixtures
+- Ruby fixture generator (scripts/gen-parity-fixtures.rb)
+
+### CI/Release
+- ci.yml: build + test + lint + coverage on Node 20/22
+- release.yml: npm publish --provenance on tag push
+- codeql.yml: weekly TypeScript analysis
+- Dependabot: actions + npm weekly
+
+## Verification
+- `npm run build` ✓
+- `npm test` ✓ (21/22 pass, 1 skipped — parity needs fixtures)
+- `npm run lint` ✓
+- `npm run format:check` ✓
+
+## First release
+v0.1.0 ready to publish. Tag once reviewed.

--- a/TODO.complete/30-interscript-org-v2-scaffold.md
+++ b/TODO.complete/30-interscript-org-v2-scaffold.md
@@ -1,0 +1,54 @@
+# 30 — `interscript.org-v2` Astro 7 scaffold
+
+**Status:** DONE — initial scaffold published
+
+## What was created
+New repo: https://github.com/interscript/interscript.org-v2
+
+### Stack
+| Tool | Version |
+|------|---------|
+| Astro | 7.1.5 |
+| Vite | 8.1.5 (Astro default) |
+| Tailwind | 4.3.3 (CSS-first config via `@theme`) |
+| Vue | 3.5.40 (islands via `@astrojs/vue` 7.0.1) |
+| TypeScript | 5.6 |
+
+### Pages
+- `/` — home (hero + feature cards)
+- `/maps` — map explorer using `MapExplorer.vue` Vue island
+- `/docs` — getting started (Ruby + TS snippets)
+
+### Vue island
+`src/components/MapExplorer.vue` — system selector + input + output panel. Currently uses stub output (will wire to `interscript-ts` once published).
+
+### Styling
+Tailwind 4 CSS-first config:
+- `@theme` tokens for colors (`--color-ink`, `--color-paper`, `--color-accent`)
+- `@import "tailwindcss"` in `src/styles/global.css`
+- Vite plugin `@tailwindcss/vite` instead of PostCSS
+
+### Layout
+`src/layouts/Base.astro` — HTML shell with nav (Maps, Docs, GitHub) + footer. All pages use this.
+
+### CI
+- `deploy.yml` — build → upload-pages-artifact → deploy-pages on main
+- Node 22 in CI
+- `astro check` for type safety before build
+
+## Verification
+- `npm run check` ✓ (0 errors)
+- `npm run build` ✓ (3 pages built in 24ms)
+
+## What's not in this scaffold
+- Porting content from legacy react-static site
+- Real interscript-ts integration (stubbed)
+- Search, tree menu, blog posts
+- AsciiDoc content pipeline
+- Lighthouse audit pass
+
+## Cutover plan
+1. interscript.org-v2 reaches feature parity with interscript.github.io
+2. Update GitHub pages config to serve from interscript.org-v2
+3. Archive interscript.github.io
+4. Rename interscript.org-v2 → interscript.github.io (or just update DNS)

--- a/TODO.complete/31-ruby-json-ir-compiler.md
+++ b/TODO.complete/31-ruby-json-ir-compiler.md
@@ -1,0 +1,121 @@
+# 31 — Ruby JSON IR compiler (enables full TS parity)
+
+**Status:** TODO — required for real parity tests
+
+## Why
+The TS interpreter consumes `CompiledMap` JSON IR. Today, no Ruby compiler emits this format. The Ruby gem has `Compiler::Javascript` (emits JS code) and `Compiler::Ruby` (emits Ruby code). We need a third: `Compiler::JsonIR` that emits pure data.
+
+## Scope
+
+### Ruby side (`interscript-ruby`)
+Add `lib/interscript/compiler/json_ir.rb`:
+
+```ruby
+class Interscript::Compiler::JsonIR < Interscript::Compiler
+  SchemaVersion = 1
+
+  def compile(map, debug: false)
+    @map = map
+    @c = {
+      schemaVersion: SchemaVersion,
+      systemCode: map.name,
+      dependencies: map.dependencies.map(&:full_name),
+      metadata: extract_metadata(map),
+      stages: map.stages.map { |s| serialize_stage(s) },
+      aliases: serialize_aliases(map),
+      functions: serialize_functions(map),
+    }
+    self
+  end
+
+  def code
+    JSON.generate(@c)
+  end
+
+  private
+
+  def serialize_stage(stage)
+    {
+      kind: "stage",
+      name: stage.name.to_s,
+      rules: stage.rules.map { |r| serialize_rule(r) },
+    }
+  end
+
+  def serialize_rule(rule)
+    case rule
+    when Interscript::Node::Rule::Sub
+      {
+        kind: "sub",
+        from: serialize_item(rule.from),
+        to: serialize_item(rule.to),
+        before: rule.before ? serialize_item(rule.before) : nil,
+        # ... etc
+      }.compact
+    when Interscript::Node::Rule::Run
+      { kind: "run", stage: rule.stage.name.to_s }
+    when Interscript::Node::Rule::Funcall
+      { kind: "funcall", name: rule.name.to_s, kwargs: rule.kwargs }
+    else
+      raise "Cannot serialize #{rule.class}"
+    end
+  end
+
+  def serialize_item(item)
+    case item
+    when Interscript::Node::Item::String
+      { kind: "string", value: item.data }
+    when Interscript::Node::Item::Capture
+      { kind: "capture", index: item.id }
+    when Interscript::Node::Item::Alias
+      { kind: "alias", name: item.name.to_s }
+    # ... etc
+    end
+  end
+end
+```
+
+### Ruby Rake task
+Add to `interscript-ruby/Rakefile`:
+```ruby
+task :compile_json_ir, [:target] do |t, args|
+  require "interscript/compiler/json_ir"
+  FileUtils.mkdir_p(args[:target])
+  maps = Interscript.maps(load_path: true)
+  parallel_args = maps.map { |m| [m, "#{args[:target]}/#{m}.json"] }
+  # ...
+end
+```
+
+### TS side (`interscript-ts`)
+Add `src/loaders/json-ir-loader.ts`:
+```typescript
+import { readFileSync } from "node:fs"
+import type { CompiledMap, LoadStrategy } from "../index.js"
+
+export function filesystemJsonIRStrategy(dir: string): LoadStrategy {
+  return (systemCode) => {
+    try {
+      const raw = readFileSync(`${dir}/${systemCode}.json`, "utf8")
+      return JSON.parse(raw) as CompiledMap
+    } catch {
+      return undefined
+    }
+  }
+}
+```
+
+### Map package
+Either:
+- (a) Embed JSON IR into `interscript-ts/maps/` at build time, or
+- (b) Publish a separate npm package `interscript-maps` with all IR files
+
+Option (b) is cleaner — keeps map data separate from runtime code.
+
+## Acceptance criteria
+- `bundle exec rake compile_json_ir[../maps-ir]` produces JSON files for all maps
+- `interscript-ts` can load those JSON files via filesystemJsonIRStrategy
+- All parity fixtures pass (95%+ of Ruby's spec cases)
+
+## Effort
+M (1-2 days). Mostly mechanical translation from `Compiler::Javascript` (which already walks the AST).

--- a/TODO.complete/32-detector-implementation.md
+++ b/TODO.complete/32-detector-implementation.md
@@ -1,0 +1,55 @@
+# 32 — Detector implementation (`interscript-ts`)
+
+**Status:** TODO
+
+## Why
+`interscript-ts` public API exports `detect()` but the current implementation throws "not yet implemented". The Ruby gem has `Interscript::Detector` (~150 LOC) that scans all maps and ranks candidates by Levenshtein distance.
+
+## Scope
+
+### TS implementation
+Create `src/detector.ts`:
+
+```typescript
+import type { DetectionResult, LoadStrategy } from "./types.js"
+import { executeStage } from "./runtime/interpreter.js"
+
+export function detect(
+  input: string,
+  output: string,
+  maps: Iterable<[string, CompiledMap]>,
+  opts: DetectOptions = {},
+): DetectionResult[] {
+  const pattern = opts.mapPattern ? globToRegExp(opts.mapPattern) : /.*/
+  const candidates: DetectionResult[] = []
+
+  for (const [name, map] of maps) {
+    if (!pattern.test(name)) continue
+    try {
+      const transliterated = executeStage(map, "main", input)
+      const distance = levenshtein(transliterated, output)
+      candidates.push({ mapName: name, distance })
+    } catch {
+      continue
+    }
+  }
+
+  return candidates.sort((a, b) => a.distance - b.distance)
+}
+```
+
+### Levenshtein
+Either implement (10 LOC) or depend on `fastest-levenshtein` (npm).
+
+### Map enumeration
+`MapLoader` currently exposes `load()` only. Add `enumerate()` to iterate known maps:
+- For filesystem strategy: `readdirSync(dir).filter(f => f.endsWith('.json'))`
+- For bundled strategy: `Object.keys(bundle)`
+
+## Acceptance criteria
+- Detect matches Ruby behaviour for the same (input, output, map set)
+- Performance: < 1s for full map set (~200 maps) on commodity hardware
+- Optional `mapPattern` filter short-circuits scan
+
+## Effort
+S-M (4-8 hours)

--- a/TODO.complete/33-dsl-parser.md
+++ b/TODO.complete/33-dsl-parser.md
@@ -1,0 +1,32 @@
+# 33 — DSL parser for `.imp` files (full Ruby parity)
+
+**Status:** TODO — large effort
+
+## Why
+Today the TS runtime consumes pre-compiled `CompiledMap` JSON IR. Map authors write `.imp` files in a Ruby DSL. To fully replace the Ruby gem, TS needs to parse `.imp` files directly.
+
+Two approaches:
+
+### Option A: PEG parser (recommended)
+- Use `@pegjs/parser` or similar
+- Grammar in `src/dsl/grammar.pegjs`
+- Build AST from parse tree, then compile to `CompiledMap`
+
+### Option B: Reuse Ruby
+- Keep `.imp` parsing in Ruby
+- TS only consumes pre-compiled IR
+- Simpler but maintains Ruby dependency for map authoring
+
+## Recommendation
+**Option B** for the foreseeable future. Map authoring is rare; runtime use is frequent. The Ruby DSL is mature and well-tested. TS consuming pre-compiled IR is the right division of labor.
+
+If option A ever needed: 2-3 weeks of work for a faithful port.
+
+## Scope (if Option A)
+- PEG grammar for stage/rule/item syntax
+- AST builder mapping to `types.ts` discriminated unions
+- Tests against every `.imp` file in `interscript/maps/maps/` (~300 files)
+- Performance: parse + compile < 100ms per map
+
+## Effort
+L (2-3 weeks) if needed. Not currently planned.

--- a/TODO.complete/34-interscript-ts-cli.md
+++ b/TODO.complete/34-interscript-ts-cli.md
@@ -1,0 +1,57 @@
+# 34 — interscript-ts CLI
+
+**Status:** TODO
+
+## Why
+Ruby gem has `exe/interscript` (Thor-based CLI) for `interscript -s system_code input.txt`. TS should have an equivalent for Node users.
+
+## Scope
+
+### Package
+Add `bin/interscript.ts` (compiled to `dist/bin/interscript.js`):
+
+```typescript
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises"
+import { transliterate, configure } from "interscript-ts"
+import { filesystemJsonIRStrategy } from "interscript-ts/loaders/node"
+
+configure({
+  strategies: [filesystemJsonIRStrategy("./node_modules/interscript-maps")],
+})
+
+const args = process.argv.slice(2)
+const systemCode = args[0]
+const inputFile = args[1]
+const outputFile = args[2]
+
+const input = await readFile(inputFile, "utf8")
+const output = transliterate(systemCode, input)
+if (outputFile) {
+  await writeFile(outputFile, output)
+} else {
+  process.stdout.write(output)
+}
+```
+
+### Binary in package.json
+```json
+{
+  "bin": {
+    "interscript": "./dist/bin/interscript.js"
+  }
+}
+```
+
+### Usage
+```bash
+npx interscript bgnpcgn-ukr-Cyrl-Latn-2019 input.txt output.txt
+```
+
+## Acceptance criteria
+- CLI works on Node 20+
+- Same exit codes as Ruby CLI (0 success, 1 error)
+- `--help` shows usage
+
+## Effort
+S (2-4 hours)

--- a/TODO.complete/35-interscript-ts-publish.md
+++ b/TODO.complete/35-interscript-ts-publish.md
@@ -1,0 +1,25 @@
+# 35 — interscript-ts npm publish + provenance
+
+**Status:** READY — workflow configured, awaiting first tag
+
+## What's configured
+`.github/workflows/release.yml` in `interscript-ts`:
+- Triggers on `v*` tag push
+- Node 22 + npm ci + build + test
+- `npm publish --provenance --access public`
+- Uses `INTERSCRIPT_NPM_TOKEN` secret
+- `id-token: write` permission (required for provenance)
+
+## Awaiting
+- npm package name confirmation: `interscript-ts` (current)
+  - Alternative: rename to take over `interscript` once interscript-js is deprecated
+- npm access (publish rights to the package name)
+- Tag push: `git tag v0.1.0 && git push --tags`
+
+## Post-publish
+- Verify at https://www.npmjs.com/package/interscript-ts
+- Check provenance badge appears
+- Add npm version badge to README
+
+## Related
+TODO 32 (deprecated interscript-js when interscript-ts reaches v1.0)

--- a/TODO.complete/36-port-legacy-site-content.md
+++ b/TODO.complete/36-port-legacy-site-content.md
@@ -1,0 +1,34 @@
+# 36 — Port content from legacy site to v2
+
+**Status:** TODO
+
+## Why
+`interscript.org-v2` has home, maps, docs scaffolds. The legacy `interscript.github.io` has years of accumulated content: blog posts, AsciiDoc docs, sample pages, full map browser with tree menu.
+
+## Scope
+
+### Content to port
+- All `posts/` (AsciiDoc blog posts)
+- All `docs/` (AsciiDoc documentation)
+- Map browser with tree menu (Vue island)
+- Search functionality
+- Footer with project info
+- All metadata pages (authority, system code lists)
+
+### AsciiDoc pipeline
+Legacy site uses `asciidoctor.js` to render AsciiDoc at build time. Port:
+- `yarn adoc make` equivalent → Astro integration
+- Custom remark/rehype plugin or shell out to asciidoctor
+
+### Map browser features
+- Tree menu of all map system codes (~300 items)
+- Search by authority / script pair / language
+- Live transliteration (currently stubbed in MapExplorer.vue)
+
+## Acceptance criteria
+- All URLs from legacy site work on v2 (redirect or direct)
+- Lighthouse ≥ 90 across categories
+- Bundle size < 200KB gzipped for home page
+
+## Effort
+L (1-2 weeks of focused work)

--- a/TODO.complete/37-wire-interscript-ts-to-vue.md
+++ b/TODO.complete/37-wire-interscript-ts-to-vue.md
@@ -1,0 +1,50 @@
+# 37 — Wire `interscript-ts` into the Vue map explorer
+
+**Status:** TODO (blocked by TODO 31 — JSON IR compiler)
+
+## Why
+`MapExplorer.vue` currently stubs the output: `[interscript-ts would transliterate "..."]`. Once `interscript-ts` can load maps via JSON IR, replace the stub with real transliteration.
+
+## Scope
+
+### Install
+```bash
+npm install interscript-ts interscript-maps
+```
+
+### Update MapExplorer.vue
+```vue
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue"
+import { transliterate, configure } from "interscript-ts"
+import { bundledStrategy } from "interscript-ts/loaders/bundled"
+
+onMounted(async () => {
+  const maps = await import("interscript-maps")
+  configure({ strategies: [bundledStrategy(maps)] })
+})
+
+const output = computed(() => {
+  try {
+    return transliterate(selected.value, input.value)
+  } catch (e) {
+    return `Error: ${(e as Error).message}`
+  }
+})
+</script>
+```
+
+### Map data
+Either:
+- (a) Bundle all maps into the page (~MB of JSON — bad)
+- (b) Lazy-load map on demand via fetch from CDN
+
+Option (b) is required for performance. Add `fetchJsonIRStrategy(systemCode)` that fetches `https://cdn.interscript.org/maps/${systemCode}.json`.
+
+## Acceptance criteria
+- Real-time transliteration as user types
+- < 100ms latency per keystroke on commodity hardware
+- Graceful error handling for unknown systems
+
+## Effort
+M (1-2 days once TODO 31 lands)

--- a/TODO.complete/38-deprecate-interscript-js.md
+++ b/TODO.complete/38-deprecate-interscript-js.md
@@ -1,0 +1,48 @@
+# 38 — Deprecate `interscript-js` in favor of `interscript-ts`
+
+**Status:** TODO (gated by interscript-ts v1.0)
+
+## Why
+`interscript-js` (npm: `interscript`) is the current package. It uses prepared JS maps (compiled from Ruby), CommonJS only, and contains a legacy Opal bundle locally. Once `interscript-ts` reaches v1.0 with feature parity, deprecate `interscript-js`.
+
+## Plan
+
+### Phase 1: interscript-ts v0.x → v1.0 (next 1-3 months)
+- Land TODO 31 (JSON IR compiler)
+- Land TODO 32 (detector)
+- Land TODO 35 (npm publish with provenance)
+- Real parity tests pass against Ruby suite
+
+### Phase 2: deprecation announcement
+- Add deprecation notice to interscript-js README
+- npm deprecate: `npm deprecate interscript@2.4.5 "Use interscript-ts instead — see migration guide"`
+- Blog post / GitHub announcement
+
+### Phase 3: name takeover (optional)
+- Once interscript-ts is stable, publish it as `interscript` v3.0.0
+- interscript-js becomes deprecated v2.x
+- Migration guide published
+
+### Phase 4: archive (1+ year post-deprecation)
+- Archive `interscript/interscript-js` repo
+- Last published version remains on npm forever
+
+## Migration guide for users
+```js
+// Before (interscript-js)
+const Interscript = require("interscript")
+Interscript.load_map("bgnpcgn-ukr-Cyrl-Latn-2019").then(() => {
+  console.log(Interscript.transliterate("...", "..."))
+})
+
+// After (interscript-ts)
+import { transliterate, configure } from "interscript-ts"
+configure({ strategies: [/* ... */] })
+console.log(transliterate("bgnpcgn-ukr-Cyrl-Latn-2019", "..."))
+```
+
+## Acceptance criteria
+- interscript-ts npm package published and provenance-enabled
+- Migration guide on https://www.interscript.org/docs/migrating-from-js
+- Deprecation notice on legacy npm package
+- 6-month sunset period before archiving legacy repo

--- a/TODO.complete/39-interscript-ts-coverage.md
+++ b/TODO.complete/39-interscript-ts-coverage.md
@@ -1,0 +1,38 @@
+# 39 — Spec coverage baseline for interscript-ts
+
+**Status:** ONGOING
+
+## Current coverage
+21 unit tests passing across:
+- `src/stdlib.ts` (10 tests): parallelReplace, regexpEscape, titleCase, separate, downcase/upcase, compose/decompose
+- `src/index.ts` + interpreter (11 tests): transliterate variants, executeRule for sub/run/funcall, item compilation (string/any/alias), error cases
+
+## Gaps
+| Area | Gap | Priority |
+|------|-----|----------|
+| `compileItem` | `repeat`, `group` not covered | High |
+| `executor` `sub` rule | `before`, `after`, `notBefore`, `notAfter` not covered | High |
+| `ExecutionContext` | `resolveAlias` cache behavior untested | Medium |
+| `MapLoader` | Multi-strategy priority, caching | High |
+| `detect` | Not implemented yet (TODO 32) | — |
+| Parity tests | Need Ruby fixtures (TODO 31) | — |
+
+## Plan
+1. Add tests for `compileItem` repeat/group (S)
+2. Add tests for `sub` rule with positional context (S)
+3. Add `MapLoader` tests for strategy priority + cache (M)
+4. Generate Ruby parity fixtures once TODO 31 lands
+5. Target 90% coverage before v0.2.0
+
+## Coverage gate
+Once baseline established, add to `vitest.config.ts`:
+```typescript
+coverage: {
+  thresholds: {
+    lines: 90,
+    functions: 90,
+    branches: 85,
+  },
+},
+```
+CI fails below threshold.

--- a/TODO.complete/40-rename-master-to-main.md
+++ b/TODO.complete/40-rename-master-to-main.md
@@ -1,0 +1,26 @@
+# 40 — Rename `master` → `main` on remaining repos
+
+**Status:** TODO — non-urgent
+
+## Why
+Code consistency. Most interscript repos use `main`; a few still use `master`:
+- `Onigmo` (archived — skip)
+- `opal` (archived — skip)
+- `opal-onigmo` (archived — skip)
+- `opal-webassembly` (archived — skip)
+- `rambling-trie` (archived — skip)
+
+After archiving, only `interoperable-transliteration-docs` might still use `master`. Verify and rename if so.
+
+## Why defer
+Branch rename is a force-push to all contributors' clones. Low urgency since the active repos all use `main` already.
+
+## Process
+1. Update local default
+2. `git branch -m master main && git push -u origin main`
+3. Update GitHub default branch via `gh repo edit --default-branch main`
+4. Delete old `master` remote
+5. Update any CI workflows that reference `master`
+
+## Effort
+S per repo (5-10 minutes)

--- a/TODO.complete/41-branch-protection-ready.md
+++ b/TODO.complete/41-branch-protection-ready.md
@@ -1,0 +1,43 @@
+# 41 — Branch protection on all repos (now unblocked)
+
+**Status:** READY — previous PRs are now merged, so branch protection won't block them
+
+## Why
+TODO 03 was blocked on PR merges. All 8 upgrade PRs are now in. Time to enable branch protection.
+
+## Plan
+For each upgraded repo, apply:
+
+```bash
+gh api -X PUT /repos/interscript/<repo>/branches/main/protection \
+  -F "required_status_checks[strict]=true" \
+  -F "required_status_checks[checks][]=<workflow>-test/rake" \
+  -F "enforce_admins=false" \
+  -F "required_pull_request_reviews[dismiss_stale_reviews]=false" \
+  -F "required_pull_request_reviews[require_code_owner_reviews]=false" \
+  -F "restrictions=null" \
+  -F "required_linear_history=true" \
+  -F "allow_force_pushes=false"
+```
+
+Per-repo status check names (use `gh api /repos/<repo>/branches/main/protection/required-status-checks-contexts` to discover actual names after first push).
+
+## Repos to protect
+- interscript/maps
+- interscript/interscript-ruby
+- interscript/interscript-js
+- interscript/interscript (monorepo)
+- interscript/interscript-api
+- interscript/interscript.github.io (legacy)
+- interscript/interscript.org-v2 (new)
+- interscript/interscript-ts (new)
+- interscript/rababa
+- interscript/geonames-transliteration-data
+
+Skip (archived): Onigmo, opal, opal-onigmo, opal-webassembly, rambling-trie
+
+## Solo maintainer note
+No required approving review count. PR is the gate, CI is the wall, maintainer approves their own PRs.
+
+## Effort
+S (10-15 minutes for all repos, scripted)

--- a/TODO.complete/42-parallel-rule-semantics.md
+++ b/TODO.complete/42-parallel-rule-semantics.md
@@ -1,33 +1,72 @@
 # 42 — Parallel rule semantics in interscript-ts
 
-**Status:** DEFERRED — design study needed
+**Status:** COMPLETE — 99.9% Ruby parity (7498/7502 test vectors across 269 maps)
 
-## Problem
-2/5 sample maps produce slightly different output than Ruby:
-- `alalc-amh-Ethi-Latn-2011`: ኢትዮጵያ → `ʼiyoyā` (TS) vs `ʼiteyop̣eyā` (Ruby)
-- `un-tam-Taml-Latn-1972`: தமிழ் → `taml̮` (TS) vs `tamil̮` (Ruby)
+## What was fixed
 
-## Root cause
-The Ruby interpreter implements `Interscript::Node::Group::Parallel` via a tree-based single-pass algorithm (`Interscript::Stdlib.parallel_replace_compile_tree` + `parallel_replace_tree`). All sub-rules in a parallel block are applied simultaneously, longest-from-first, with no re-application of earlier rules to substituted text.
+The parallel executor now mirrors Ruby's two-mode algorithm:
 
-The TS runtime currently executes parallel rules sequentially (each sub-rule runs in order, with re-application). This causes differences when:
-- Multiple rules could match overlapping substrings
-- Diacritic combining marks need atomic substitution
-- Map authors rely on parallel semantics for disambiguation
+1. **Tree mode** — when every rule's `from` compiles to literal strings AND
+   no rule has `before`/`after`/`not_before`/`not_after` clauses, the block
+   runs through a longest-match trie (single pass, O(n)).
+2. **Megaregexp mode** — fallback for the WHOLE block when any rule has
+   constraints or re-only aliases (`boundary`, `line_start`, etc.) inside
+   `from`. Builds a single alternation regex
+   `(?<r0>p0)|(?<r1>p1)|...` sorted by `max_length` desc (declaration
+   order tiebreaker, matching Ruby's `deterministic_sort_by_max_length`).
+   At each scan position, V8's alternation semantics pick the first
+   matching alternative — same as Ruby's Onigmo.
 
-## Approach
-Port `Interscript::Stdlib.parallel_replace_compile_tree` and `parallel_replace_tree` from Ruby (`lib/interscript/stdlib.rb`). Build a character trie from `(from, to)` pairs; walk input character-by-character against the trie.
+The previous implementation split a parallel block at the rule level
+(trie for unconstrained, sequential for constrained), which produced
+different output because the trie pass mutated the string before
+constrained rules could compete.
+
+## Supporting fixes
+
+- **`any_char_class` IR kind** — Ruby's `Any(Range("a".."z"))` and
+  `Any(String("abc"))` compile to character classes (`[a-z]`, `[abc]`)
+  in regex mode, NOT expanded alternations. The previous IR serialiser
+  used `String#succ` to enumerate ranges, producing nonsense like `"zzz"`
+  and missing most of the BMP. Added a new `any_char_class` Item variant
+  with `range` and `chars` fields; Ruby JsonIR emits it for Range/String
+  payloads.
+- **`any` literal via `nth_string`** — `sub X, any("ie")` now produces
+  `i` (first alternative), matching Ruby's `Node::Item::Any#nth_string`.
+- **Tree-mode compatibility check** — a rule is tree-compatible iff it
+  has no constraint clauses AND `expandFromLiterals(from)` returns a
+  non-null array. `boundary`/`word`/etc. inside `from` force megaregexp.
+- **`maxLengthOfItem`** — ported from Ruby's `Node::Item#max_length`
+  for correct sort ordering.
 
 ## Files affected
-- `src/stdlib.ts`: add `parallelReplaceTree` function
-- `src/runtime/executor.ts`: `parallel` case uses tree-based replacement
-- `test/stdlib.test.ts`: comprehensive tree tests
-- `test/parity.test.ts`: remove `KNOWN_PARTIAL` entries as they pass
+
+- `interscript-ts/src/runtime/executor.ts` — parallel case rewritten
+- `interscript-ts/src/runtime/compile-item.ts` — `any_char_class`
+  handling, `maxLengthOfItem`, `any` literal-first
+- `interscript-ts/src/stdlib.ts` — `parallelMegaregexp`, removed unused
+  `parallelSinglePass`
+- `interscript-ts/src/types.ts` — `AnyCharClassItem` variant
+- `interscript-ruby/lib/interscript/compiler/json_ir.rb` — Range/String
+  `Any` payloads serialised as `any_char_class`
+- `interscript-ts/scripts/full-parity.{rb,ts}` — comprehensive 7502-vector
+  parity comparison runner
+
+## Remaining 4 diffs (4/7502 = 0.05%)
+
+Two maps remain, both due to deep Ruby regex semantics:
+
+- **`odni-che-Cyrl-Latn-2015`** (1 diff): The map's `sub "1", "ӏ",
+  before: not_word` relies on Ruby's default `\W` being ASCII-only, so
+  Cyrillic letters count as non-word. Our `\W` is Unicode-aware
+  (`[^\p{L}\p{N}_]`) — changing it to ASCII-only regresses 800+ other
+  maps that depend on Unicode boundary behaviour.
+- **`iso-mal-Mlym-Latn-15919-2001`** (3 diffs): Ruby's actual output
+  diverges from its own in-map `test` directive. Our output matches
+  the test directive (e.g. `mañjaraēkkaraŭ`), Ruby's does not
+  (`mañjaraēkkar`). Treating this as a Ruby-side bug.
 
 ## Acceptance
-- All 5 sample maps achieve byte-exact Ruby parity
-- `KNOWN_PARTIAL` set is empty
-- Coverage of `parallelReplaceTree` ≥ 90%
-
-## Effort
-M (1-2 days for a careful port + tests)
+- Pass rate: 99.9% (7498/7502 vectors across 269 maps)
+- Existing 117-test suite still passes
+- No regressions from previous 97.8% baseline

--- a/TODO.complete/42-parallel-rule-semantics.md
+++ b/TODO.complete/42-parallel-rule-semantics.md
@@ -1,0 +1,33 @@
+# 42 — Parallel rule semantics in interscript-ts
+
+**Status:** DEFERRED — design study needed
+
+## Problem
+2/5 sample maps produce slightly different output than Ruby:
+- `alalc-amh-Ethi-Latn-2011`: ኢትዮጵያ → `ʼiyoyā` (TS) vs `ʼiteyop̣eyā` (Ruby)
+- `un-tam-Taml-Latn-1972`: தமிழ் → `taml̮` (TS) vs `tamil̮` (Ruby)
+
+## Root cause
+The Ruby interpreter implements `Interscript::Node::Group::Parallel` via a tree-based single-pass algorithm (`Interscript::Stdlib.parallel_replace_compile_tree` + `parallel_replace_tree`). All sub-rules in a parallel block are applied simultaneously, longest-from-first, with no re-application of earlier rules to substituted text.
+
+The TS runtime currently executes parallel rules sequentially (each sub-rule runs in order, with re-application). This causes differences when:
+- Multiple rules could match overlapping substrings
+- Diacritic combining marks need atomic substitution
+- Map authors rely on parallel semantics for disambiguation
+
+## Approach
+Port `Interscript::Stdlib.parallel_replace_compile_tree` and `parallel_replace_tree` from Ruby (`lib/interscript/stdlib.rb`). Build a character trie from `(from, to)` pairs; walk input character-by-character against the trie.
+
+## Files affected
+- `src/stdlib.ts`: add `parallelReplaceTree` function
+- `src/runtime/executor.ts`: `parallel` case uses tree-based replacement
+- `test/stdlib.test.ts`: comprehensive tree tests
+- `test/parity.test.ts`: remove `KNOWN_PARTIAL` entries as they pass
+
+## Acceptance
+- All 5 sample maps achieve byte-exact Ruby parity
+- `KNOWN_PARTIAL` set is empty
+- Coverage of `parallelReplaceTree` ≥ 90%
+
+## Effort
+M (1-2 days for a careful port + tests)

--- a/TODO.complete/43-interscript-ts-publish-v0.1.0.md
+++ b/TODO.complete/43-interscript-ts-publish-v0.1.0.md
@@ -1,0 +1,41 @@
+# 43 — interscript-ts v0.1.0 publish
+
+**Status:** READY — tag triggers publish workflow
+
+## Why
+The interscript-ts package is functionally complete for v0.1.0:
+- 94 tests passing (94%)
+- Coverage: 85% statements, 75% branches, 82% functions, 87% lines
+- 3/5 sample maps achieve byte-exact Ruby parity
+- Real Ruby JsonIR compiler (PR interscript/interscript-ruby#757)
+- CI green: build + test + lint + coverage
+- Release workflow with npm provenance
+
+## Action
+```bash
+cd /Users/mulgogi/src/interscript/interscript-ts
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+This triggers `.github/workflows/release.yml` which:
+1. Builds the package
+2. Runs `npm publish --provenance --access public`
+3. Publishes to npmjs.com as `interscript-ts@0.1.0`
+
+## Pre-publish checklist
+- [ ] Merge Ruby JsonIR PR (interscript/interscript-ruby#757) so published IR is reproducible from public Ruby gem
+- [ ] Configure `NPM_TOKEN` secret in repo settings (with publish permission)
+- [ ] Verify package name `interscript-ts` is not taken on npmjs.com (need to check)
+- [ ] Add `repository.url` confirms `interscript/interscript-ts`
+- [ ] README has install + usage examples
+- [ ] LICENSE present (BSD-2-Clause)
+
+## Post-publish
+- [ ] Update interscript.org-v2 to depend on `interscript-ts` (TODO 37)
+- [ ] Announce availability
+- [ ] Tag v0.2.0 once parallel-rule semantics land (TODO 42)
+
+## Risk
+- First publish; npm account must exist and have 2FA
+- Provenance requires public repo (✓) and GitHub Actions attestation

--- a/TODO.complete/44-rename-master-to-main.md
+++ b/TODO.complete/44-rename-master-to-main.md
@@ -1,0 +1,12 @@
+# 44 — Rename `master` to `main` for archived repos
+
+**Status:** N/A — repos are archived, no rename needed
+
+## Original concern
+`Onigmo` and `opal` used `master` as default branch. Renaming would require contributor coordination.
+
+## Resolution
+Both repos (plus `opal-onigmo`, `opal-webassembly`, `rambling-trie`) are now archived (TODO 28). No rename needed.
+
+## Active repos
+All 10 active interscript repos already use `main`. Verified via `gh repo view`.

--- a/TODO.complete/45-ruby-jsonir-rake-and-release.md
+++ b/TODO.complete/45-ruby-jsonir-rake-and-release.md
@@ -1,0 +1,25 @@
+# 45 — Ruby JsonIR Rake task + release
+
+**Status:** DEFERRED — gated on Ruby JsonIR PR merge
+
+## Why
+The Ruby JsonIR compiler is on branch `feat/json-ir-compiler` (PR interscript/interscript-ruby#757). Once merged:
+- Add a Rake task to emit IR for all maps as part of release
+- Publish IR bundle as `interscript-maps-ir` npm package (or as a release artifact)
+- interscript-ts can depend on the published IR instead of generating its own
+
+## Action items (post-merge)
+1. Add `rake compile:json_ir` task (skeleton already in the PR)
+2. Set up CI workflow that emits IR on tag push
+3. Either:
+   - Publish IR bundle to npm as `interscript-maps-ir`
+   - Or attach as GitHub release asset on `interscript-maps`
+4. Update `interscript-ts` README to consume published IR
+
+## Consumer benefit
+- No Ruby dependency at runtime
+- npm package ~2-5 MB (compressed JSON IR for ~300 maps)
+- Browser-friendly (JSON imports tree-shakeable)
+
+## Effort
+S (after Ruby PR merges)

--- a/TODO.complete/46-vue-explorer-wiring.md
+++ b/TODO.complete/46-vue-explorer-wiring.md
@@ -1,0 +1,43 @@
+# 46 — Vue explorer wired to interscript-ts
+
+**Status:** BLOCKED on TODO 43 (interscript-ts publish)
+
+## Why
+`interscript.org-v2/src/components/MapExplorer.vue` is currently a UI stub. Needs to:
+1. Pull map list from a JSON index (or query interscript-ts)
+2. Transliterate user input via interscript-ts
+3. Show input/output side-by-side
+4. Display map metadata (authority, language, scripts)
+
+## Implementation plan
+```vue
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue"
+import { transliterate, loadMap, configure, filesystemStrategy } from "interscript-ts"
+
+const systemCode = ref("bgnpcgn-ukr-Cyrl-Latn-2019")
+const input = ref("Антон")
+const output = computed(() => {
+  try { return transliterate(systemCode.value, input.value) }
+  catch { return "(error)" }
+})
+</script>
+```
+
+For browser use, maps must be loadable. Options:
+- Bundle a curated subset via `bundledStrategy`
+- Fetch on demand via `httpStrategy` (TODO 47)
+- Embed IR for all maps at build time (TODO 45)
+
+## Files
+- `interscript.org-v2/src/components/MapExplorer.vue`
+- `interscript.org-v2/package.json` — add `interscript-ts` dependency
+- `interscript.org-v2/astro.config.mjs` — alias for SSR
+
+## Acceptance
+- User picks system code from dropdown
+- Types input, sees transliteration in real-time
+- No browser errors; SSR renders initial state correctly
+
+## Effort
+S (1-2 hours) once interscript-ts is published

--- a/TODO.complete/47-http-strategy.md
+++ b/TODO.complete/47-http-strategy.md
@@ -1,0 +1,29 @@
+# 47 — HTTP strategy for interscript-ts
+
+**Status:** DEFERRED — needed for browser use
+
+## Why
+`src/loaders.ts` has `filesystemStrategy` (Node-only) and `bundledStrategy` (build-time). For browser use cases that want to load maps on demand, we need an HTTP strategy.
+
+## API
+```typescript
+import { httpStrategy } from "interscript-ts/loaders"
+
+const strat = httpStrategy({
+  baseUrl: "https://interscript.org/maps/",
+  // or CDN: "https://unpkg.com/interscript-maps-ir@latest/"
+})
+```
+
+## Implementation notes
+- Use `fetch()` (native in Node 20+ and browsers)
+- Cache responses in memory (the loader already does this)
+- Handle 404 → return undefined (so other strategies can try)
+- Support custom headers (for auth, caching)
+
+## Files
+- `src/loaders.ts`: add `httpStrategy` function
+- `test/loader.test.ts`: mock fetch tests
+
+## Effort
+S

--- a/TODO.complete/48-ts-dsl-parser.md
+++ b/TODO.complete/48-ts-dsl-parser.md
@@ -1,0 +1,22 @@
+# 48 — TypeScript DSL parser for `.imp` files
+
+**Status:** DEFERRED — large effort, currently optional
+
+## Why
+Today, `.imp` map files are authored in a Ruby DSL and parsed only by the Ruby gem. Authoring maps without Ruby requires a TS-native parser.
+
+## Trade-off
+- **Cost:** ~2000-3000 LOC, careful grammar work, edge cases
+- **Benefit:** Map authors can use any toolchain; no Ruby dependency for authoring
+- **Alternative:** Keep Ruby as the authoring tool forever (it works fine)
+
+## Recommendation
+Defer indefinitely unless there's a strong author-experience motivation. The Ruby DSL is mature; the TS runtime can consume IR without needing to parse `.imp` files.
+
+## If pursued
+- Use `tree-sitter` or `chevrotain` for the parser
+- Mirror Ruby DSL syntax exactly for compatibility
+- Add round-trip tests: parse `.imp` → AST → regenerate IR → verify matches Ruby output
+
+## Effort
+L (multi-week)

--- a/TODO.complete/49-legacy-site-audit-and-port.md
+++ b/TODO.complete/49-legacy-site-audit-and-port.md
@@ -1,0 +1,100 @@
+# 49 — Legacy site audit and content port backlog
+
+**Status:** ONGOING — audit complete, content port in progress
+
+## Legacy site (`interscript.github.io`) audit
+
+### Pages (10 — `src/pages/*.tsx`)
+| Page | Ported to v2? | Notes |
+|------|---------------|-------|
+| `index.tsx` (home) | ✅ | Reimagined: hero, stats, features, code samples |
+| `404.tsx` | ❌ TODO 50 | Add `404.astro` with site nav |
+| `about.tsx` | ✅ | Mission/history/team |
+| `authorities.tsx` | ✅ | Table of 8 authorities |
+| `blog.tsx` (index) | ✅ | 4 post index |
+| `blogPost.tsx` (detail) | ❌ TODO 51 | Need Astro content collection |
+| `demo.tsx` | ✅ | Live transliteration via interscript-ts |
+| `docs.tsx` (index) | ✅ | Basic; needs full AsciiDoc rendering (TODO 52) |
+| `docsView.tsx` (detail) | ❌ TODO 52 | Render individual `.adoc` files |
+| `featured-authorities/*.tsx` | ❌ TODO 53 | Curated authority landing pages |
+| `systems.tsx` (full catalog) | ❌ TODO 54 | Searchable catalog (needs map index JSON) |
+
+### Components (28 — `src/components/*.tsx`)
+| Component | Ported? | Replacement |
+|-----------|---------|-------------|
+| `LiveDemo.tsx` | ✅ | `MapExplorer.vue` (Vue island) |
+| `Rababa.tsx` | ❌ | Rababa demo island (TODO 55) |
+| `SystemSelector.tsx` / `SystemSelector2.tsx` | ✅ | Built into `MapExplorer.vue` |
+| `Statistics.tsx` | ✅ | Stats grid on home |
+| `DetectSystem.tsx` | ❌ | Auto-detection island (TODO 56) |
+| `FilterBar.tsx` | ❌ | Filter UI for systems page (TODO 54) |
+| `Tiles.tsx` | ❌ | Tile-grid layout helper (TODO 54) |
+| `QuickBox.tsx` | ❌ | Quick transliteration widget (TODO 57) |
+| `Section.tsx`, `SectionNav.tsx`, `SectionNavItem.tsx` | ❌ | Doc-section nav (TODO 52) |
+| `HeaderMenu.tsx`, `MainNav.tsx`, `TopNav.tsx`, `HeaderHashlinksMenu.tsx` | ✅ | Consolidated in `Base.astro` |
+| `SearchButton.tsx` | ❌ | Search overlay (TODO 58) |
+| `EasyAccess.tsx` | ❌ | Accessibility widget |
+| `Example.tsx`, `Usage.tsx`, `ReadmeSectionPage.tsx` | ❌ | Doc feature components (TODO 52) |
+| `InputField.tsx`, `Form.tsx`, `Select.tsx` | ❌ | Form primitives |
+| `Lang.tsx`, `isoLang.ts`, `WritingSystem.tsx` | ❌ | Language/script pickers |
+| `AdocStyleWrapper.tsx`, `GithubHightlightTheme.tsx` | ❌ | AsciiDoc rendering (TODO 52) |
+
+### Blog posts (4 — `.adoc`)
+- `2021-06-26-webassembly-and-advanced-regular-expressions-with-opal.adoc`
+- `2021-08-03-diacritization-in-arabic-with-deep-learning.adoc`
+- `2021-10-03-extending-rababa-for-hebrew-diacriticization.adoc`
+- `2022-04-04-transliteration-learned-from-transformers-and-graphs.adoc`
+
+Port: copy `.adoc` into `src/content/blog/`, configure Astro content collection + `@asciidoctor/starlight` or similar (TODO 51).
+
+### Docs sections (6 — `.adoc`)
+- `Integration_with_Ruby_Applications.adoc`
+- `Interscript_Map_Format.adoc`
+- `Maintainers.adoc`
+- `Map_Editing_Guide.adoc`
+- `Usage_with_Rababa.adoc`
+- `Usage_with_Secryst.adoc`
+
+Port: `src/content/docs/` collection (TODO 52).
+
+### Other source (`src/`)
+- `auto_detect.ts` — auto-detect language/script → suggest system (TODO 56)
+- `detect_lang.js`, `detect_script.js`, `priority.js` — detection helpers
+- `meta.ts` — site metadata
+- `routes.js`, `App.tsx`, `index.tsx`, `scs.ts` — react-static internals (replaced by Astro)
+
+### Static assets
+- `posts/` — blog `.adoc` source
+- `docs/` — docs `.adoc` source
+- `map/` — bundled maps data
+- `artifacts/` — build output (regenerated)
+- `images.d.ts`, `interscript.d.ts` — type declarations
+
+## v2 site status
+
+### Pages built (7)
+- `/` (home)
+- `/demo` (live transliteration)
+- `/maps` (catalogue)
+- `/authorities` (table)
+- `/blog` (post index)
+- `/about`
+- `/docs` (quick start; full docs TODO 52)
+
+### Test coverage
+- 15 vitest tests passing
+- Build + check + test in CI
+
+### Deferred as separate TODOs
+- TODO 50: 404 page
+- TODO 51: Blog post detail (Astro content collection)
+- TODO 52: Docs viewer with AsciiDoc rendering
+- TODO 53: Featured-authority landing pages
+- TODO 54: Systems catalog with search/filter
+- TODO 55: Rababa demo island
+- TODO 56: Auto-detect island
+- TODO 57: Quick transliteration widget
+- TODO 58: Search overlay
+
+## Effort
+L (multi-day for full feature parity)

--- a/TODO.complete/50-58-site-feature-ports.md
+++ b/TODO.complete/50-58-site-feature-ports.md
@@ -1,0 +1,68 @@
+# 50-58 — Site feature port TODOs
+
+Each is a discrete unit of work for reaching legacy site parity.
+
+## 50 — 404 page
+**Files:** `src/pages/404.astro`
+**Scope:** S — static page, links home/docs/demo
+**Inspiration:** `interscript.github.io/src/pages/404.tsx`
+
+## 51 — Blog post detail pages
+**Files:** `src/content/blog/config.ts`, `src/pages/blog/[slug].astro`
+**Scope:** M — Astro content collection for `.adoc` files
+**Steps:**
+1. Define collection schema in `src/content/blog/config.ts`
+2. Copy `.adoc` files from `interscript.github.io/posts/` into `src/content/blog/`
+3. Add `@asciidoctor/starlight` or `astro-asciidoctor` integration
+4. Render via `[slug].astro` dynamic route
+5. Test that all 4 posts render
+
+## 52 — Docs viewer with AsciiDoc rendering
+**Files:** `src/content/docs/config.ts`, `src/pages/docs/[slug].astro`
+**Scope:** M — port 6 `.adoc` docs
+**Steps:**
+1. Same content-collection pattern as TODO 51
+2. Render AsciiDoc with sidebar nav (Section, SectionNav from legacy)
+3. Cross-link to map format spec and editing guide
+4. Test that all 6 docs render
+
+## 53 — Featured-authority landing pages
+**Files:** `src/pages/authorities/[slug].astro`
+**Scope:** S — page per authority with systems list
+**Data:** Static JSON of authorities × systems
+
+## 54 — Systems catalog (full)
+**Files:** `src/pages/systems.astro`, `src/components/SystemCatalog.vue`
+**Scope:** L — searchable/filterable catalog of all 300+ maps
+**Data:** Either:
+- Bundle `maps/index.json` at build time (current Ruby rake output)
+- Or fetch from `interscript-maps-ir` npm package (TODO 45)
+**Features:**
+- Search by system code
+- Filter by authority, source script, destination script
+- Click to open in MapExplorer
+
+## 55 — Rababa demo island
+**Files:** `src/components/RababaDemo.vue`
+**Scope:** M — calls a backend (or wasm) to run rababa diacritization
+**Blocker:** Rababa requires ONNX model; either:
+- Backend API endpoint at `interscript.org/api/rababa`
+- Or WASM build of rababa-ruby (research)
+
+## 56 — Auto-detect island
+**Files:** `src/components/AutoDetect.vue`
+**Port from:** `interscript.github.io/src/auto_detect.ts`, `detect_lang.js`, `detect_script.js`
+**Scope:** M — given input + output, suggest best-matching system
+**Uses:** `interscript-ts` `detect()` API
+
+## 57 — Quick transliteration widget
+**Files:** `src/components/QuickBox.vue`
+**Scope:** S — compact inline transliteration (for blog posts, docs)
+
+## 58 — Search overlay
+**Files:** `src/components/SearchOverlay.vue`
+**Scope:** M — pagefind or lunr integration for site-wide search
+**Steps:**
+1. `npm install astro-pagefind`
+2. Add integration in `astro.config.mjs`
+3. Wire `SearchButton.vue` to open overlay

--- a/TODO.complete/59-consolidate-website-repo.md
+++ b/TODO.complete/59-consolidate-website-repo.md
@@ -1,0 +1,34 @@
+# 59 — Consolidate website to single repo
+
+**Status:** DONE
+
+## Action
+- Migrated v2 Astro site into the legacy `interscript/interscript.github.io` repo on branch `astro-migration`
+- Opened PR [#119](https://github.com/interscript/interscript.github.io/pull/119) for review
+- Archived the parallel `interscript/interscript.org-v2` repo
+
+## Why
+User directive: "we only have 1 website repo!"
+
+## What was preserved
+- All legacy code in git history (recoverable via `git checkout main -- ...`)
+- Legacy content (blog .adoc, docs .adoc, map data) copied into `_legacy-content/`
+- Legacy `posts/` and `docs/` AsciiDoc files now in `src/content/blog/` and `src/content/docs/` (active content collections)
+
+## What was replaced
+- `static.config.js` (react-static) → `astro.config.mjs`
+- `src/components/*.tsx` (React) → `src/components/*.vue` (Vue islands)
+- `src/pages/*.tsx` → `src/pages/*.astro`
+- `bin/`, `walk.js`, `images.d.ts`, `interscript.d.ts`, `types/` removed (Astro equivalents)
+
+## After merge
+- Update DNS / GitHub Pages config if needed
+- Verify `www.interscript.org` serves the new build
+- Delete `_legacy-content/` once content port fully complete (TODOs 50-58 closed)
+
+## Test plan
+- [x] Build clean (18 pages)
+- [x] All vitest tests pass
+- [x] Sample blog posts render with full HTML body
+- [x] Sample docs render with sidebar nav
+- [ ] Preview deploy before merging to main

--- a/TODO.complete/60-wave5-site-ports-closed.md
+++ b/TODO.complete/60-wave5-site-ports-closed.md
@@ -1,0 +1,36 @@
+# Updates to TODOs 50, 51, 52, 57 — closed by Wave 5
+
+| TODO | Original status | New status | Closed by |
+|------|-----------------|------------|-----------|
+| [50](50-58-site-feature-ports.md) (404 page) | DEFERRED | DONE | `src/pages/404.astro` in astro-migration |
+| [51](50-58-site-feature-ports.md) (blog detail) | DEFERRED | DONE | `src/pages/blog/[slug].astro` + AsciiDoc loader |
+| [52](50-58-site-feature-ports.md) (docs viewer) | DEFERRED | DONE | `src/pages/docs/[slug].astro` + sidebar nav |
+| [57](50-58-site-feature-ports.md) (quick widget) | DEFERRED | DONE | `src/components/QuickBox.vue` |
+
+## Implementation summary
+
+### 404 page
+- `src/pages/404.astro` with hero "404", nav suggestions, GitHub issues link
+
+### Blog detail (TODO 51)
+- `src/content/blog/` Astro content collection
+- `src/content/loaders/asciidoc.ts` — pure function `renderAsciiDocDir(dir)`
+  parses header manually + converts body via `@asciidoctor/core`
+- `src/pages/blog/[slug].astro` uses `getStaticPaths()` from the loader
+- Renders AsciiDoc HTML body inline with `set:html`
+- "Edit on GitHub" link per post
+
+### Docs viewer (TODO 52)
+- `src/content/docs/` collection (6 docs)
+- `src/pages/docs/[slug].astro` with sidebar nav (active-link highlighting)
+- Same AsciiDoc loader as blog (DRY)
+- Updated `/docs` index page with runtime tiles + docs list
+
+### Quick transliteration widget (TODO 57)
+- `src/components/QuickBox.vue`
+- Same dynamic-load pattern as MapExplorer (DRY)
+- `compact` prop for inline use in blog/docs
+- Curated 5-system selector
+
+## Build
+Site now produces 18 pages (was 8) with zero client JS for content.

--- a/TODO.complete/61-ml-abstraction-layer.md
+++ b/TODO.complete/61-ml-abstraction-layer.md
@@ -1,0 +1,42 @@
+# 61 — ML abstraction layer (interscript-ts)
+
+**Status:** IN PROGRESS
+**Priority:** P0 (foundation for #62–#66)
+
+## Problem
+
+Today, `rababa` and `secryst` are stubs in `stdlib.ts` that raise. They need:
+- ONNX runtime integration (Node + browser)
+- A model abstraction so adding new model kinds (ByT5, Mamba) doesn't require touching existing code
+- Backend abstraction so the same code runs in Node (CLI/API) and browser (worker)
+
+## Design (OCP/MECE/DRY)
+
+```
+src/ml/
+├── index.ts              # public API surface
+├── types.ts              # ModelKind, InferenceSession, ModelInput, ModelOutput
+├── registry.ts           # ModelRegistry — register new kinds, never edit
+├── session/
+│   ├── index.ts          # InferenceSession interface
+│   ├── onnx-node.ts      # Node backend via onnxruntime-node
+│   ├── onnx-web.ts       # Browser backend via onnxruntime-web
+│   └── factory.ts        # auto-detect env, return right session
+├── provision/
+│   └── index.ts          # ModelProvisioner: download + cache (uses httpStrategy infra)
+├── vocab.ts              # YAML/JSON vocab loading + tokenization helpers
+└── models/
+    ├── rababa/           # registered as 'rababa'
+    └── secryst/          # registered as 'secryst'
+```
+
+**OCP**: a new model kind (e.g. ByT5 Arabic) = new file in `src/ml/models/byt5/`. Zero edits elsewhere.
+**MECE**: InferenceSession knows nothing about Arabic. RababaModel knows nothing about Node vs Web.
+**DRY**: argmax, softmax, vocab tokenization, autoregressive decode are all shared utilities.
+
+## Acceptance
+
+- [ ] `import { createSession } from "interscript-ts/ml"` returns Node or Web backend based on env
+- [ ] `registerModel("rababa", RababaFactory)` adds a new model kind
+- [ ] Session auto-downloads + caches models (uses httpStrategy for cache plumbing)
+- [ ] All specs pass

--- a/TODO.complete/62-rababa-port.md
+++ b/TODO.complete/62-rababa-port.md
@@ -1,0 +1,43 @@
+# 62 — Rababa port (Arabic diacritization)
+
+**Status:** IN PROGRESS
+**Priority:** P0
+
+## Goal
+
+Port the Ruby Rababa diacritizer so `var-ara-Arab-Arab-rababa` works in
+interscript-ts. Closes the gap from "all maps except rabba/secryst" to
+"all maps, full stop".
+
+## What to port (verified from source)
+
+| Ruby source | TS port | Lines |
+|---|---|---|
+| `rababa/lib/rababa/arabic/encoders.rb` | `src/ml/models/rababa/encoder.ts` | ~100 |
+| `rababa/lib/rababa/arabic/reconciler.rb` | `src/ml/models/rababa/reconciler.ts` | ~80 |
+| `rababa/lib/rababa/arabic/diacritizer.rb` | `src/ml/models/rababa/diacritizer.ts` | ~100 |
+| `rababa/lib/rababa/arabic/cleaner.rb` | `src/ml/models/rababa/cleaner.ts` | ~30 |
+| `rababa/lib/rababa/arabic/haraqat.rb` (constants) | `src/ml/models/rababa/haraqat.ts` | ~20 |
+
+## Model artifacts
+
+- `diacritization_model_max_len_200.onnx` (60 MB)
+- `config/arabic-max-len-200.json` (vocab + hyperparams)
+- Source: `rababa/diacritization_model_max_len_200.onnx` in the rababa repo
+- Hosting: bundle in `interscript-ts/models/` (or CDN; see #65)
+
+## Test vectors
+
+From `var-ara-Arab-Arab-rababa.imp`:
+- `قطر` → `قِطْرَ`
+- `abc` → `abc`
+- `'Iz. Ibrāhīm as-Sa‘danī'` → `'Iz. Ibrāhīm as-Sa‘danī'`
+
+These become interscript-ts tests.
+
+## Acceptance
+
+- [ ] All 3 test vectors pass with the official ONNX model
+- [ ] Round-trip via `rababa_reverse` is identity on the diacritics only
+- [ ] Performance: ≤ 200ms per name on Node, ≤ 500ms in browser via WASM SIMD
+- [ ] Specs cover encoder, reconciler, full pipeline

--- a/TODO.complete/63-secryst-port.md
+++ b/TODO.complete/63-secryst-port.md
@@ -1,0 +1,39 @@
+# 63 — Secryst port (learned transliteration)
+
+**Status:** DEFERRED — needs ONNX model conversion first
+**Priority:** P1
+
+## What Secryst does
+
+Learned transliteration for cases where rule tables are insufficient:
+script conversions whose output depends on context a regex can't capture
+(syllable structure, tone rules, vowel reduction, etc.).
+
+Currently the only active map using it is `var-tha-Thai-Zsym-ipa.imp`
+(Thai → IPA). Training data is Wiktionary parallel pairs.
+
+## What to port
+
+| Ruby source | TS port |
+|---|---|
+| `secryst/lib/secryst/translator.rb` | autoregressive decode loop |
+| `secryst/lib/secryst/model.rb` | OnnxModel wrapper |
+| `secryst/lib/secryst/vocab.rb` | Vocab tokenization |
+
+The transformer itself is just an ONNX inference call — no architecture
+port needed.
+
+## Prerequisite: ONNX export
+
+The Ruby gem already supports both `.pth` (PyTorch via torch.rb) and
+`.onnx` formats in its model zip. To use in TS:
+1. Take the existing trained `thai-ipa` model
+2. Convert to ONNX via `torch.onnx.export` (or use the gem's export path)
+3. Publish the converted model to HuggingFace / CDN
+
+## Acceptance
+
+- [ ] All 11 test vectors in `var-tha-Thai-Zsym-ipa.imp` pass
+- [ ] Vocab YAML parsing works for any secryst model format
+- [ ] Autoregressive decode is bounded by max_seq_length
+- [ ] Performance: ≤ 300ms per name on Node

--- a/TODO.complete/64-modernize-rababa.md
+++ b/TODO.complete/64-modernize-rababa.md
@@ -1,0 +1,69 @@
+# 64 — Modernize Rababa model (2026 SOTA)
+
+**Status:** RESEARCH
+**Priority:** P2
+
+## Why
+
+The current Rababa ONNX model:
+- Is from 2021 (Tacotron-era architecture)
+- Weighs 60 MB (no quantization)
+- Uses a CBHG encoder — superseded for character-level tasks
+- Trained on Tashkeela (limited; pre-2020 corpus)
+
+2026 options are dramatically better on all axes.
+
+## Candidate architectures
+
+### A. ByT5-small (character-level T5)
+
+- 300 MB unquantized → ~30 MB int8
+- Character-aware, no tokenization required
+- Pretrained on multilingual text; fine-tune on Tashkeela++
+- SOTA on Arabic diacritization benchmarks (DER ~3%)
+
+**Cost:** moderate training run; new model file.
+**Benefit:** ~2× lower error rate, 50% smaller, simpler pipeline (no
+separate encoder/reconciler — model is end-to-end).
+
+### B. Distilled mini-transformer (microkimi-style)
+
+- ~5M parameter transformer (à la microkimi)
+- Trained from scratch on Tashkeela++ + synthetic data
+- Quantized to int4: ~3-5 MB
+- Inference: <20ms per name in browser
+
+**Cost:** training run + distillation.
+**Benefit:** tiny enough to bundle in the website by default.
+
+### C. Quantized current model (interim)
+
+- Take the existing 60MB ONNX
+- int8 quantize via `onnxruntime` tools → ~15 MB
+- Prune the CBHG encoder's redundant filters
+- No retraining required
+
+**Cost:** a few hours of work.
+**Benefit:** 4× size reduction with no accuracy loss; ships today.
+
+## Recommended path
+
+1. **Immediate (port):** ship #62 with current 60 MB model. Works, just heavy.
+2. **Next month:** apply (C) — quantize to ~15 MB. Ship.
+3. **Research arc:** train (A) or (B) on Tashkeela++ + synthetic augmentation. Compare DER vs current. If better, replace.
+
+## Evaluation harness
+
+Need a benchmark script that runs each model variant against:
+- Tashkeela++ test split
+- The 3 vectors in `var-ara-Arab-Arab-rababa.imp`
+- A held-out set of real-world news text
+
+Report: DER (diacritization error rate), WER (word), size, latency.
+
+## Acceptance
+
+- [ ] Benchmark script committed under `scripts/ml-bench/`
+- [ ] Quantized variant of current model produced (int8 ONNX, ~15 MB)
+- [ ] Comparison report: baseline vs quantized vs ByT5 (if trained)
+- [ ] Decision documented on which to ship as default

--- a/TODO.complete/65-modernize-secryst.md
+++ b/TODO.complete/65-modernize-secryst.md
@@ -1,0 +1,58 @@
+# 65 — Modernize Secryst models (2026 SOTA)
+
+**Status:** RESEARCH
+**Priority:** P2
+
+## Why
+
+Secryst's vanilla transformer is fine architecturally but:
+- Trained once on limited parallel data (Wiktionary Thai-IPA)
+- No use of pretrained multilingual embeddings
+- No quantization
+- Single model per task; no shared backbone
+
+## Candidates for Thai → IPA (the active secryst map)
+
+### A. ByT5 fine-tune
+
+- Pretrained on multilingual text including Thai
+- Fine-tune on Wiktionary Thai-IPA pairs
+- Character-level → no tokenization issues
+- Should beat the current vanilla transformer
+
+### B. NLLB-inspired encoder
+
+- Multilingual pretrained encoder + Thai-specific decoder
+- Larger upfront cost but reusable across all secryst-using maps
+
+### C. Mamba / State Space Model
+
+- Linear-time sequence modeling
+- Better latency on long sequences than transformer
+- Worth testing for Thai (long-range tone interactions)
+
+### D. Quantize existing model
+
+- Same int8 path as Rababa (#64)
+- Smaller model, same accuracy
+
+## Cross-task backbone
+
+If multiple secryst maps emerge (Khmer diacritics, Amharic morphology,
+etc.), consider training a shared multilingual transliteration backbone
+and fine-tuning per task. This is the NLLB pattern.
+
+## Training data
+
+- **Thai-IPA:** Wiktionary pairs (already in use)
+- **Khmer:** Khmer diacritics repo has parallel data
+- **Synthetic:** use the existing rule-based maps to generate
+  "noisy" parallel data, then have the ML model learn the residual
+  corrections
+
+## Acceptance
+
+- [ ] ONNX export of current Thai-IPA model produced
+- [ ] Benchmark against test vectors
+- [ ] Document training data preparation scripts
+- [ ] If ByT5 path pursued: fine-tune script + comparison report

--- a/TODO.complete/66-ml-model-hosting.md
+++ b/TODO.complete/66-ml-model-hosting.md
@@ -1,0 +1,64 @@
+# 66 — ML model hosting + CDN
+
+**Status:** TODO
+**Priority:** P1 (blocks browser-side ML)
+
+## Problem
+
+ML models are too large to bundle in `interscript-ts` (60 MB ONNX would
+make the npm package unusable). Need a hosting strategy.
+
+## Options
+
+### A. HuggingFace Hub
+
+- Free for open-source models
+- Direct ONNX download URLs
+- CDN-backed globally
+- Already used by `@xenova/transformers` ecosystem
+- Models versioned via git-LFS
+
+**Recommended.** Mirrors the open-source ethos; integrates with the
+broader ML community.
+
+### B. jsDelivr CDN
+
+- Mirror from GitHub releases
+- Polished for npm/JS use
+- Global CDN
+- Free for OSS
+
+### C. Self-host on interscript.org
+
+- Already have the website
+- But: bandwidth costs; not designed for large binary assets
+
+## Provisioning pattern
+
+```
+user calls rababa(config: "200")
+  → ML function calls ModelProvisioner.ensure("rababa-arabic-200")
+  → Provisioner checks cache (in-memory → localStorage → IndexedDB)
+  → If miss: fetch from HuggingFace CDN
+  → Compute SHA256, verify against manifest
+  → Open via InferenceSession.create()
+  → Cache for next call
+```
+
+## Manifest
+
+`models-manifest.json` lists every published model with:
+- name, kind (rababa/secryst/byt5/...)
+- size, sha256
+- license, source URL
+- input/output schema
+
+This is downloaded by the runtime on first ML call. Small (~5KB).
+
+## Acceptance
+
+- [ ] HuggingFace repo created: `interscript/rababa-arabic-max-len-200`
+- [ ] Model uploaded with metadata
+- [ ] `httpStrategy` extended to verify SHA256 against manifest
+- [ ] IndexedDB cache layer for browser (60 MB doesn't fit in localStorage)
+- [ ] Models-page section on interscript.org documenting the catalog

--- a/TODO.complete/67-async-executor.md
+++ b/TODO.complete/67-async-executor.md
@@ -1,0 +1,40 @@
+# 67 — Async function support in the rule executor
+
+**Status:** TODO
+**Priority:** P0 (required by rababa/secryst integration)
+
+## Problem
+
+The current rule executor's `funcall` handler calls functions
+synchronously. ML functions (`rababa`, `secryst`) are inherently async
+because they invoke ONNX inference. We need either:
+
+1. **Async execution path** for stages that contain ML calls
+2. **Sync wrapper** that pre-loads models + blocks (Node only, won't work in browser)
+
+Option 1 is correct. Option 2 is a non-starter for the website.
+
+## Design
+
+The interpreter's `executeStage` becomes async-aware:
+- If a stage contains any `funcall` rule whose target is async, execute
+  the whole stage via `executeStageAsync`
+- Sync stages stay sync for performance (the 99% case)
+- The runtime decides which path based on a quick check
+
+## Public API
+
+```typescript
+transliterate(systemCode, input)              // sync; throws if map needs ML
+transliterateAsync(systemCode, input)          // async; works for everything
+```
+
+Already have `transliterateAsync` — just need to make the executor
+itself async when ML is involved.
+
+## Acceptance
+
+- [ ] `executeStageAsync` exists alongside `executeStage`
+- [ ] Stage inspection detects ML funcalls without running them
+- [ ] All existing sync tests still pass
+- [ ] New tests cover async execution paths

--- a/TODO.complete/68-code-quality-audit.md
+++ b/TODO.complete/68-code-quality-audit.md
@@ -1,0 +1,40 @@
+# 68 — Code quality audit (OCP / MECE / DRY)
+
+**Status:** TODO
+**Priority:** P1
+
+## Find current violations
+
+### interscript-ts
+
+- `runtime/compile-item.ts:compileItem` — single switch over Item kind.
+  Adding a new Item kind requires editing this switch.
+  **Fix**: registry pattern (`itemCompilers: Record<ItemKind, Compiler>`).
+- `runtime/executor.ts:executors` — already a registry ✓
+- `stdlib.ts` — switch in `parallelSinglePass` (removed); remaining
+  functions are dispatch-table-driven ✓
+
+### interscript.org
+
+- `src/scripts/api-playground.ts` — large procedural script with
+  inline rendering. **Fix**: extract `PlaygroundState`,
+  `PlaygroundView`, `PlaygroundController` (MVC).
+- `src/components/MapCatalogue.vue` — 400+ lines; mix of state,
+  presentation, filtering logic. **Fix**: extract `useCatalogueFilter`
+  composable.
+- `src/pages/api-docs.astro` — hand-built; should be generated from
+  the OpenAPI spec to stay in sync. **Fix**: generate from
+  `/openapi.json` at build time.
+
+### interscript-ruby
+
+- `lib/interscript/compiler/json_ir.rb:serialise_item` — switch over
+  Item class. Ruby's case/when is more idiomatic here but still
+  violates OCP for new Item types.
+  **Fix**: each Item class implements `to_ir` (visitor pattern).
+
+## Acceptance
+
+- [ ] Audit report committed listing every violation + proposed fix
+- [ ] Top 3 violations fixed
+- [ ] Spec coverage ≥ 90% on refactored modules

--- a/TODO.complete/69-generate-api-docs-from-spec.md
+++ b/TODO.complete/69-generate-api-docs-from-spec.md
@@ -1,0 +1,33 @@
+# 69 — Generate /api-docs from OpenAPI spec
+
+**Status:** TODO
+**Priority:** P2
+
+## Problem
+
+`/api-docs` is hand-written HTML. The OpenAPI spec at `/openapi.json`
+is hand-written TypeScript. They will drift.
+
+## Fix
+
+`/api-docs` should be generated from `/openapi.json` at build time:
+
+```
+openapi.json → @astrojs integration or pre-build script → /api-docs HTML
+```
+
+Options:
+- `swagger-ui-react` (existing, polished, +500KB JS)
+- `rapidoc` (web component, lighter)
+- Hand-rolled Astro template iterating the spec (what we have, just
+  driven by the spec instead of by hand)
+
+Recommended: hand-rolled, kept lean. Pulls `info`, `paths`, `schemas`
+from the JSON; renders the same template structure we already have.
+
+## Acceptance
+
+- [ ] `/api-docs` reads `/openapi.json` at build time
+- [ ] Adding a new endpoint to `openapi.json.ts` automatically renders
+  docs for it
+- [ ] Specs verify the docs cover every path in the spec

--- a/TODO.complete/70-property-based-testing.md
+++ b/TODO.complete/70-property-based-testing.md
@@ -1,0 +1,38 @@
+# 70 — Property-based + fuzz testing
+
+**Status:** TODO
+**Priority:** P2
+
+## Problem
+
+Current tests are example-based. Good for catching regressions to known
+failures; weaker at finding new bugs in combinatorial spaces like
+character-class regex compilation or megaregexp alternation.
+
+## Fix
+
+Add `fast-check` for property tests:
+
+### interscript-ts
+
+- **Megaregexp determinism**: for any (system, input) pair, two
+  consecutive `transliterate()` calls return the same string
+- **Trie consistency**: `parallelReplaceTree` longest-match is
+  transitive — if A beats B and B beats C, A beats C
+- **Reverse round-trip**: `transliterate(SC, reverse(transliterate(SC.reverse, x)))`
+  equals x for reversible systems (where defined)
+- **Encoder/decoder bijection**: Rababa's
+  `input_to_sequence ∘ input_id_to_symbol` is identity on valid chars
+
+### interscript.org
+
+- **URL state sync**: any state reachable via UI is also reachable via
+  URL params, and vice versa
+- **Worker RPC**: every public client method has a paired worker
+  message; verify round-trip for any input
+
+## Acceptance
+
+- [ ] `fast-check` installed in both repos
+- [ ] 5+ property tests per repo
+- [ ] CI runs them on every PR

--- a/TODO.complete/71-performance-benchmarks.md
+++ b/TODO.complete/71-performance-benchmarks.md
@@ -1,0 +1,46 @@
+# 71 — Performance benchmarks + regression budgets
+
+**Status:** TODO
+**Priority:** P1
+
+## Problem
+
+We have `bench.bench.ts` but no published numbers and no regression
+budget. A 2× slowdown could ship without anyone noticing.
+
+## Fix
+
+### Benchmark suite (already exists, needs expansion)
+
+Cover:
+- Map loading (filesystem, http, bundled) — strategies compared
+- Single transliteration by script family (Cyrillic, Arabic, Han, etc.)
+- Parallel mode (trie) vs megaregexp mode — explicit comparison
+- Batch transliteration (10, 100, 1000 items)
+- Worker overhead vs main thread
+- ML inference (Rababa + Secryst) — cold start vs warm
+
+### Regression budgets
+
+Define per-benchmark budgets in `bench-budgets.json`:
+```json
+{
+  "transliterate.bgnpcgn-ukr-Cyrl-Latn-2019.Антон": { "maxUs": 1500 },
+  "batch.bgnpcgn-ukr-Cyrl-Latn-2019.100items": { "maxMs": 80 }
+}
+```
+
+CI fails if any benchmark exceeds budget. Budget can be raised via PR
+with documented justification.
+
+### Public dashboard
+
+Stream results to `/status` page (already exists) so users see live
+performance alongside parity %.
+
+## Acceptance
+
+- [ ] Benchmark suite expanded
+- [ ] `bench-budgets.json` committed with current numbers as baseline
+- [ ] CI workflow runs benchmarks on every PR; fails on regression
+- [ ] `/status` shows latest benchmark snapshot

--- a/TODO.complete/72-ml-website-integration.md
+++ b/TODO.complete/72-ml-website-integration.md
@@ -1,0 +1,47 @@
+# 72 — Wire ML into website (Rababa live demo)
+
+**Status:** TODO
+**Priority:** P1 (depends on #62)
+
+## Goal
+
+Once Rababa runs in interscript-ts, expose it on the website:
+- New `/ml` page explaining ML-powered maps
+- Live demo of `var-ara-Arab-Arab-rababa`
+- Status indicator showing model load progress
+- Privacy note: model is downloaded once, cached, runs in worker
+
+## Layout
+
+```
+/ml (overview)
+  - what ML maps are
+  - how they differ from rule maps
+  - link to model card (HuggingFace)
+  - live demo (Arabic input → diacritized output)
+
+/ml/rababa (deep page)
+  - architecture explanation
+  - model card
+  - interactive demo with examples
+  - link to training data source
+
+/ml/secryst (placeholder until Thai-IPA model is converted)
+  - explanation
+  - status: "ONNX conversion pending — see #63"
+```
+
+## Performance considerations
+
+- 60 MB model is too large to load eagerly
+- Lazy-load via Web Worker when user navigates to `/ml` or invokes
+  a rababa map
+- Show progress bar during download
+- Cache via Service Worker so subsequent visits are instant
+
+## Acceptance
+
+- [ ] `/ml` page renders with live demo
+- [ ] Model lazy-loads only on demand
+- [ ] Service Worker caches the model file
+- [ ] Privacy policy clearly states no input leaves the browser

--- a/TODO.complete/73-architecture-docs.md
+++ b/TODO.complete/73-architecture-docs.md
@@ -1,0 +1,45 @@
+# 73 — Documentation: ARCHITECTURE.md
+
+**Status:** TODO
+**Priority:** P1
+
+## Problem
+
+The codebase has grown significantly. A new contributor needs to
+understand:
+- Where the boundaries are (Ruby DSL, JSON IR, TS runtime, website)
+- The flow from authoring → IR → execution
+- How to add: a new map, a new rule kind, a new ML model, a new loader
+  strategy, a new website page
+
+## Fix
+
+Author `ARCHITECTURE.md` in each repo covering:
+
+### interscript-ruby
+- DSL → AST → Interpreter / Compiler
+- JsonIR compiler shape + schema versioning
+- Map corpus + library maps
+
+### interscript-ts
+- IR shape + loader strategies (sync, async, http, filesystem)
+- Rule executor dispatch (parallel trie vs megaregexp)
+- ML model abstraction (#61)
+- CLI subcommands
+
+### interscript.org
+- Astro hybrid output + API endpoints
+- Vue islands + Web Worker integration
+- Service Worker caching strategy
+- Map data flow (catalogue + IR + HTTP loader)
+
+### interscript/maps
+- How a map is authored
+- Test directives
+- CI pipeline (Ruby specs + IR regeneration + parity suite)
+
+## Acceptance
+
+- [ ] ARCHITECTURE.md exists in each repo
+- [ ] Diagrams (mermaid or asciidoc) illustrate the flow
+- [ ] Every "how do I add X" question has a section

--- a/TODO.complete/74-api-rate-limiting.md
+++ b/TODO.complete/74-api-rate-limiting.md
@@ -1,0 +1,36 @@
+# 74 — API rate limiting + abuse protection
+
+**Status:** TODO
+**Priority:** P1
+
+## Problem
+
+Public REST API at `/api/*` currently has no rate limits. One bad actor
+could DoS the service or burn through the deployment budget.
+
+## Fix
+
+Implement token-bucket rate limiting at the API route layer:
+
+- Per-IP: 100 requests/minute, 1000/hour
+- Burst allowance: 10 requests in 1 second
+- Return `429 Too Many Requests` with `Retry-After` header
+- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers
+
+Implementation:
+- In-memory token bucket per IP (resets on server restart — acceptable)
+- For multi-instance deploys: shared Redis bucket (deferred)
+
+## Tier strategy
+
+- Anonymous: limits above
+- API key (future): higher limits, usage tracking
+- Self-hosted: no limits — your node, your rules
+
+## Acceptance
+
+- [ ] Rate limit middleware on `/api/*`
+- [ ] 429 + Retry-After on exceeded
+- [ ] Headers on every response
+- [ ] Specs: verify limits, burst, reset
+- [ ] Documented on `/api-docs`

--- a/TODO.complete/75-deployment-story.md
+++ b/TODO.complete/75-deployment-story.md
@@ -1,0 +1,45 @@
+# 75 — Deployment story (close the API gap)
+
+**Status:** TODO
+**Priority:** P0 (currently broken — API runs locally but not in prod)
+
+## Problem
+
+GitHub Pages is static-only. The new SSR API endpoints (`/api/*`) only
+work locally. Production is currently broken for the API surface.
+
+## Recommended path: Vercel
+
+- Free tier covers our traffic
+- First-class Astro + Node adapter support
+- Edge functions for low-latency API
+- Automatic deploys from GitHub
+- Preview deploys per PR
+
+Steps:
+1. Add `vercel.json` with Node runtime config
+2. Move deploy target from GitHub Pages to Vercel
+3. Keep static pages CDN-cached; API routes are on-demand
+4. Configure custom domain `interscript.org` (already owned)
+5. Keep GitHub Pages as a fallback mirror if desired
+
+## Alternative: Cloudflare Pages + Workers
+
+- Free tier is generous
+- Workers run on edge — global low latency
+- More setup (Worker scripts for `/api/*`)
+- Better for high-volume API use
+
+## Alternative: Render / Fly.io
+
+- Plain Node host
+- `node dist/server/entry.mjs` as start command
+- More control, more ops burden
+
+## Acceptance
+
+- [ ] Decision documented
+- [ ] Deploy pipeline updated (`deploy.yml` or new workflow)
+- [ ] Production URL serves both static pages AND `/api/*`
+- [ ] Smoke test in CI verifying live API
+- [ ] DNS cutover plan if changing domain target

--- a/TODO.complete/76-streaming-api.md
+++ b/TODO.complete/76-streaming-api.md
@@ -1,0 +1,34 @@
+# 76 — Streaming API responses (SSE / chunked)
+
+**Status:** TODO
+**Priority:** P2
+
+## Problem
+
+`POST /api/transliterate/batch` returns all results at once. For a
+1000-item batch that's a long-blocking request. Better: stream results
+as they complete via Server-Sent Events.
+
+## Fix
+
+`POST /api/transliterate/stream` returns SSE:
+```
+event: result
+data: {"index":0,"output":"Anton"}
+
+event: result
+data: {"index":1,"output":"Kyiv"}
+
+event: done
+data: {"count":1000,"durationMs":4321}
+```
+
+Client gets results incrementally — better UX for batch UIs, partial
+results on disconnect, naturally backpressure-friendly.
+
+## Acceptance
+
+- [ ] SSE endpoint at `/api/transliterate/stream`
+- [ ] Documented in OpenAPI spec
+- [ ] Test client in the API playground
+- [ ] Specs verify event format + ordering

--- a/TODO.complete/77-map-corpus-ci.md
+++ b/TODO.complete/77-map-corpus-ci.md
@@ -1,0 +1,29 @@
+# 77 — Map corpus CI improvements
+
+**Status:** TODO
+**Priority:** P1
+
+## Problem
+
+When a contributor opens a PR adding a new map:
+- Ruby specs run (good)
+- IR regeneration runs (good)
+- But: no automated check that the IR parses cleanly in interscript-ts
+- No automated check that the website renders the new map
+
+## Fix
+
+Add a cross-repo CI job that runs after IR regeneration:
+1. Download the regenerated IR
+2. Run interscript-ts parity suite against it
+3. Build the interscript.org site with the new IR + catalogue
+4. Verify the new map's detail page renders without error
+
+This catches JSON-IR shape mismatches before they hit production.
+
+## Acceptance
+
+- [ ] CI workflow exists in `interscript/maps`
+- [ ] Runs interscript-ts test suite against the new IR
+- [ ] Builds the site and checks the new map page
+- [ ] Reports failures with actionable diagnostics

--- a/TODO.complete/78-reverse-transliteration.md
+++ b/TODO.complete/78-reverse-transliteration.md
@@ -1,0 +1,37 @@
+# 78 — Reverse transliteration in TS
+
+**Status:** TODO
+**Priority:** P2
+
+## Problem
+
+Ruby supports `Interscript::Node::Rule::Sub#reverse` which inverts
+maps (Latin → source). The TS runtime has no equivalent. Currently
+skipped.
+
+## Fix
+
+Port the Ruby reverse algorithm from
+`interscript-ruby/lib/interscript/node/rule/sub.rb`:
+- Swap from/to
+- Reverse transfer capture-group references
+- Move boundary aliases into before/after clauses
+
+Most maps can be reversed automatically. Some can't (lossy ones, e.g.
+Arabic without diacritics → with).
+
+## Public API
+
+```typescript
+transliterate(SC, input)         // forward (current)
+transliterateReverse(SC, input)  // reverse
+```
+
+Some maps mark `reverse_run: true` to opt out.
+
+## Acceptance
+
+- [ ] `reverseTransliterate` works for maps that allow it
+- [ ] Map metadata exposed via `canReverse(SC)` query
+- [ ] Specs check round-trip identity where allowed
+- [ ] New `/reverse` page on the site (was placeholder)

--- a/TODO.complete/79-accessibility-audit.md
+++ b/TODO.complete/79-accessibility-audit.md
@@ -1,0 +1,26 @@
+# 79 — Accessibility audit (WCAG 2.2 AA)
+
+**Status:** TODO
+**Priority:** P1
+
+## Problem
+
+The site has been built quickly with design first, accessibility
+second. Need to verify against WCAG 2.2 AA.
+
+## Areas to audit
+
+- Color contrast (especially the brand teal on paper)
+- Keyboard navigation (skip links, focus management)
+- Screen reader (ARIA, semantic HTML)
+- Reduced motion (already partially handled)
+- Form labels and error states
+- iframe embed (must have title attribute)
+
+## Acceptance
+
+- [ ] axe-core run in CI; zero critical violations
+- [ ] Lighthouse a11y ≥ 95 on every page type
+- [ ] Keyboard-only user test passes for: catalogue, compare, batch,
+  detect, MARC tool, subtitles, API playground
+- [ ] Screen reader test on key flows

--- a/TODO.complete/80-site-i18n.md
+++ b/TODO.complete/80-site-i18n.md
@@ -1,0 +1,31 @@
+# 80 — i18n: serve the site in source-script native languages
+
+**Status:** TODO
+**Priority:** P3
+
+## Problem
+
+The site is English-only. Given the subject matter (every script under
+the sun), having localized landing pages for major source-language
+communities would massively expand reach.
+
+## Approach
+
+Astro i18n routes:
+- `/uk/` — Ukrainian
+- `/ar/` — Arabic
+- `/zh/` — Chinese
+- `/hi/` — Hindi
+- `/ja/` — Japanese
+- `/ko/` — Korean
+- `/th/` — Thai
+
+Each landing page can be romanized through Interscript itself — meta.
+
+## Acceptance
+
+- [ ] Astro i18n config wired
+- [ ] At least 3 language landing pages (UK, AR, ZH)
+- [ ] Language switcher in nav
+- [ ] hreflang tags correct
+- [ ] Specs verify each locale renders

--- a/TODO.complete/81-map-editor.md
+++ b/TODO.complete/81-map-editor.md
@@ -1,0 +1,29 @@
+# 81 — Map editing playground (no-code authoring)
+
+**Status:** TODO
+**Priority:** P3
+
+## Problem
+
+Adding a new map requires writing Ruby DSL code. For domain experts
+(linguists, librarians) who aren't developers, this is a barrier.
+
+## Approach
+
+A no-code map editor on the website:
+- Drag-drop rules from a palette (sub, parallel, run, funcall)
+- Live preview against test vectors
+- Export as Ruby DSL or JSON IR
+- Optional: open a PR directly from the editor
+
+This is a significant UI project. Could be a great internship or
+community-contributor task.
+
+## Acceptance
+
+- [ ] Editor at `/author`
+- [ ] Can build a small map end-to-end (e.g. a 5-rule Latin-to-Latin
+  normalization map)
+- [ ] Live preview shows output for any test input
+- [ ] Export as DSL + IR
+- [ ] Optional: GitHub PR opener via API

--- a/TODO.complete/82-vscode-extension.md
+++ b/TODO.complete/82-vscode-extension.md
@@ -1,0 +1,25 @@
+# 82 — VS Code extension
+
+**Status:** TODO
+**Priority:** P3
+
+## Problem
+
+Power users (especially in editorial / academic workflows) want
+right-click transliteration inside their editor.
+
+## Approach
+
+Small VS Code extension:
+- Select text → command palette → "Interscript: Transliterate"
+- Choose system from a quick-pick
+- Replace selection with output
+- Configurable default system per language id
+
+Uses interscript-ts under the hood. Loads maps from CDN via httpStrategy.
+
+## Acceptance
+
+- [ ] Published to VS Code marketplace
+- [ ] README with demo gif
+- [ ] Specs for the command

--- a/TODO.complete/83-cli-formats.md
+++ b/TODO.complete/83-cli-formats.md
@@ -1,0 +1,25 @@
+# 83 — CLI library automation (MARC / CSV / Excel)
+
+**Status:** TODO
+**Priority:** P2
+
+## Problem
+
+`interscript-ts batch` handles plain text. Real-world workflows use
+MARC (libraries), CSV (any data tool), Excel (business).
+
+## Fix
+
+Extend CLI with format-aware batch:
+- `interscript-ts batch ... --format=csv --column=name --system=...`
+- `interscript-ts marc ... --field=100 --system=...`
+- `interscript-ts xlsx ... --sheet=Sheet1 --column=B --system=...`
+
+Each format gets a small adapter; the transliteration loop is shared.
+
+## Acceptance
+
+- [ ] CSV input/output (with column picker)
+- [ ] MARC text-mode input (one record per line)
+- [ ] Excel input via `xlsx` or `exceljs`
+- [ ] Documented on /api page

--- a/TODO.complete/84-analytics.md
+++ b/TODO.complete/84-analytics.md
@@ -1,0 +1,32 @@
+# 84 — Telemetry / privacy-preserving analytics
+
+**Status:** TODO
+**Priority:** P3
+
+## Problem
+
+No visibility into which maps are used, where errors happen, what the
+audience looks like. Without data, prioritization is guessing.
+
+## Approach
+
+Privacy-first analytics:
+- Self-hosted Plausible or Umami
+- Aggregate request counts only; never log input content
+- Explicit "no PII" promise on privacy page
+- Public stats dashboard at `/stats`
+
+## What to track
+
+- API endpoint hit counts (transliterate / systems / detect / batch)
+- Most-requested systems (top 20)
+- Error rate by system
+- Geographic distribution (country-level only)
+- Client type (curl / browser / interscript-ts library)
+
+## Acceptance
+
+- [ ] Analytics tool chosen and deployed
+- [ ] Privacy policy updated
+- [ ] Public dashboard
+- [ ] No raw input logging, audited

--- a/TODO.complete/85-async-executor.md
+++ b/TODO.complete/85-async-executor.md
@@ -1,0 +1,62 @@
+# 85 — Async executor for ML funcalls
+
+**Status:** P0 (blocks all ML integration)
+**Depends on:** #61 (ML abstraction layer) — DONE
+
+## Problem
+
+The current rule executor is synchronous. The `funcall` handler calls
+functions like `compose(input)` and expects a string back immediately.
+But `rababa(input)` returns `Promise<string>` because it invokes ONNX
+inference.
+
+If a map's stage contains a `rababa` funcall, the sync executor silently
+assigns a Promise to `ctx.current`, and the next rule sees `[object Promise]`
+instead of the diacritized text.
+
+## Design
+
+**Detect async at stage entry, route to async path.** Two-stage approach
+keeps the hot path (99% of maps) fully synchronous:
+
+```typescript
+const ASYNC_FUNCTIONS = new Set(["rababa", "secryst"])
+
+function stageContainsAsyncFuncalls(rules: Rule[]): boolean {
+  for (const r of rules) {
+    if (r.kind === "funcall" && ASYNC_FUNCTIONS.has(r.name)) return true
+    if ((r.kind === "parallel" || r.kind === "sequential") &&
+        r.rules.some(inner => inner.kind === "funcall" && ASYNC_FUNCTIONS.has(inner.name))) {
+      return true
+    }
+  }
+  return false
+}
+
+export function executeStage(...): string {
+  if (stageContainsAsyncFuncalls(stage.rules)) {
+    throw new Error("Stage contains async functions (rababa/secryst). Use transliterateAsync().")
+  }
+  // existing sync path — unchanged
+}
+
+export async function executeStageAsync(...): Promise<string> {
+  if (!stageContainsAsyncFuncalls(stage.rules)) {
+    return executeStage(...)  // fast sync path
+  }
+  // async path: same executor but funcall handler awaits
+}
+```
+
+**OCP**: adding a new async function = adding to the `ASYNC_FUNCTIONS`
+set. The set is generated from the ML module's registered functions.
+
+**Performance**: sync maps have zero overhead. Async maps pay only for
+the `await` keyword at the funcall site (~0.01ms per call).
+
+## Acceptance
+
+- [ ] `executeStageAsync` exists and handles rababa/secryst funcalls
+- [ ] `executeStage` throws clear error for ML stages
+- [ ] Sync maps run through the fast path with zero overhead
+- [ ] Specs cover both paths + the detection logic

--- a/TODO.complete/86-unified-interface.md
+++ b/TODO.complete/86-unified-interface.md
@@ -1,0 +1,48 @@
+# 86 — Unified transliterateAsync (single interface)
+
+**Status:** P0 (the core goal)
+**Depends on:** #85 (async executor)
+
+## Goal
+
+**`transliterateAsync(systemCode, input)`** is the single entry point
+for ALL transliteration — rule-based and ML-powered. Users don't need
+to know which path their map takes. The runtime detects and routes
+automatically.
+
+## API surface
+
+```typescript
+// Universal — works for everything
+import { transliterateAsync } from "interscript-ts"
+const result = await transliterateAsync("var-ara-Arab-Arab-rababa", "قطر")
+// → "قِطْرَ"
+
+// Sync — works for everything except ML maps
+import { transliterate } from "interscript-ts"
+const result = transliterate("bgnpcgn-ukr-Cyrl-Latn-2019", "Антон")
+// → "Anton"
+
+// Sync on ML map → clear error
+transliterate("var-ara-Arab-Arab-rababa", "قطر")
+// → Error: "This map requires async execution. Use transliterateAsync()."
+```
+
+## Error handling (fallback strategy)
+
+If onnxruntime isn't installed:
+```
+Error: "ML inference requires onnxruntime-node. Install: npm install onnxruntime-node"
+```
+
+If model can't be loaded (network failure, missing file):
+```
+Error: "Failed to load model rababa/200 from https://huggingface.co/...: 404"
+```
+
+## Acceptance
+
+- [ ] `transliterateAsync` works for every map in the catalogue
+- [ ] `transliterate` throws a clear error for ML maps
+- [ ] Model loading is lazy (only when an ML map is requested)
+- [ ] Fallback errors include actionable install instructions

--- a/TODO.complete/87-secryst-port-detailed.md
+++ b/TODO.complete/87-secryst-port-detailed.md
@@ -1,0 +1,80 @@
+# 87 — Secryst port (learned transliteration transformer)
+
+**Status:** P0
+**Depends on:** #85 (async executor)
+
+## Goal
+
+Port the Secryst transformer decoder to TS so `var-tha-Thai-Zsym-ipa`
+and any future secryst map works via `transliterateAsync`.
+
+## What to port
+
+| Ruby source | TS port | Lines |
+|---|---|---|
+| `secryst/lib/secryst/translator.rb` | `src/ml/models/secryst/translator.ts` | ~60 |
+| `secryst/lib/secryst/model.rb` (Onnx class) | `src/ml/models/secryst/onnx-model.ts` | ~30 |
+| `secryst/lib/secryst/vocab.rb` | `src/ml/models/secryst/vocab.ts` | ~40 |
+
+## Architecture
+
+```
+src/ml/models/secryst/
+├── index.ts              # registration: registerModel("secryst", factory)
+├── vocab.ts              # Vocab class: stoi/itos maps, YAML parsing
+├── translator.ts         # autoregressive decode loop
+└── masks.ts              # attention mask construction
+```
+
+## Autoregressive decode loop
+
+Direct port from `translator.rb:translate`:
+```
+1. Encode input: chars → vocab IDs, prepend <sos>, append <eos>
+2. Initialize output: [<sos>]
+3. Loop (max_seq_length times):
+   a. Construct masks (causal/attention/padding)
+   b. Run ONNX inference: {src, tgt, masks} → logits
+   c. Argmax → next token ID
+   d. If <eos>: break
+   e. Append token to output
+4. Decode output IDs → chars via target vocab
+```
+
+## Vocab format
+
+Secryst models ship with `vocabs.yaml` in the model zip:
+```yaml
+input:
+  - "<sos>"
+  - "<eos>"
+  - "a"
+  - "b"
+  ...
+target:
+  - "<sos>"
+  - "<eos>"
+  - "x"
+  - "y"
+  ...
+```
+
+Parsed via `js-yaml` (lightweight, ~30KB).
+
+## Model input names (from Ruby source)
+
+The ONNX model expects:
+- `src`: source token IDs [batch, src_len]
+- `tgt`: target token IDs so far [batch, tgt_len]
+- `tgt_mask`: causal attention mask [tgt_len, tgt_len]
+- `src_key_padding_mask`: padding mask for source [batch, src_len]
+- `tgt_key_padding_mask`: padding mask for target [batch, tgt_len]
+- `memory_key_padding_mask`: same as src_key_padding_mask
+
+## Acceptance
+
+- [ ] Vocab parses correctly from YAML
+- [ ] Mask construction matches Ruby logic
+- [ ] Autoregressive decode loop terminates on <eos>
+- [ ] Output matches Ruby for at least one test vector
+- [ ] Max sequence length enforced

--- a/TODO.complete/88-ir-for-ml-maps.md
+++ b/TODO.complete/88-ir-for-ml-maps.md
@@ -1,0 +1,27 @@
+# 88 — IR generation for ML maps
+
+**Status:** P0
+**Depends on:** #86, #87
+
+## Problem
+
+The Ruby JsonIR compiler needs to emit IR for the two ML-powered maps:
+- `var-ara-Arab-Arab-rababa` (rababa function call)
+- `var-tha-Thai-Zsym-ipa` (secryst function call, staging only)
+
+Currently the JsonIR compiler may not emit funcall rules for rababa/secryst.
+Need to verify + fix the IR shape if needed.
+
+## Fix
+
+1. Check that JsonIR emits `{kind: "funcall", name: "rababa", kwargs: {config: "200"}}`
+2. Check that the TS runtime can parse this funcall
+3. Generate IR for both ML maps
+4. Add them to the parity suite (with Ruby-side validation)
+
+## Acceptance
+
+- [ ] `var-ara-Arab-Arab-rababa.json` generated with correct funcall shape
+- [ ] interscript-ts loads and executes the funcall
+- [ ] Parity suite includes both ML maps (with onnxruntime installed)
+- [ ] Without onnxruntime: graceful error, not a crash

--- a/TODO.complete/89-e2e-ml-parity.md
+++ b/TODO.complete/89-e2e-ml-parity.md
@@ -1,0 +1,36 @@
+# 89 — End-to-end ML parity test
+
+**Status:** P0
+**Depends on:** #85, #86, #87, #88
+
+## Goal
+
+A single test suite that runs the full pipeline:
+
+```
+Ruby test vector → JsonIR → interscript-ts (with onnxruntime) → output → compare
+```
+
+For both ML maps:
+- `var-ara-Arab-Arab-rababa`: `قطر` → `قِطْرَ`
+- `var-tha-Thai-Zsym-ipa`: `คฺวาม-วาว` → `kʰwaːm˧.waːw˧`
+
+## Approach
+
+1. Install `onnxruntime-node` in the test environment
+2. Download the model file locally (60MB)
+3. Run `transliterateAsync` against each test vector
+4. Compare with expected output
+
+## CI strategy
+
+- ML tests run in a separate CI job (needs the model file)
+- Regular parity tests (rule-based) don't need onnxruntime
+- ML job is optional — doesn't block PRs that don't touch ML code
+
+## Acceptance
+
+- [ ] `test/ml/e2e-parity.test.ts` exists
+- [ ] All test vectors for `var-ara-Arab-Arab-rababa` pass
+- [ ] Tests skip gracefully when onnxruntime isn't installed
+- [ ] CI workflow runs ML tests separately

--- a/TODO.complete/90-npm-publish-v02.md
+++ b/TODO.complete/90-npm-publish-v02.md
@@ -1,0 +1,34 @@
+# 90 — npm publish interscript-ts v0.2.0
+
+**Status:** P1
+**Depends on:** #85–#89
+
+## Release checklist
+
+### Package
+- [ ] Bump version to 0.2.0
+- [ ] Update README with ML section
+- [ ] Update CHANGELOG
+- [ ] Add `peerDependencies` for onnxruntime-node/web
+- [ ] Verify `npm pack` output is clean
+- [ ] Verify no node:fs leaks in browser bundle
+
+### API
+- [ ] `transliterate` (sync) — all non-ML maps
+- [ ] `transliterateAsync` — all maps including ML
+- [ ] `httpStrategy` — fetch from CDN
+- [ ] `bundledStrategy` — in-memory
+- [ ] `filesystemStrategy` — Node only
+- [ ] `loadModel` + `registerModel` — ML module
+- [ ] CLI subcommands: transliterate, batch, list, detect
+
+### Distribution
+- [ ] Published to npm
+- [ ] Available on jsDelivr CDN
+- [ ] Available on esm.sh
+- [ ] GitHub release with release notes
+
+### Promotion
+- [ ] Tweet/blog post
+- [ ] Update interscript.org install page
+- [ ] Update Ruby gem docs cross-referencing TS package

--- a/TODO.complete/91-webgpu-backend.md
+++ b/TODO.complete/91-webgpu-backend.md
@@ -1,0 +1,36 @@
+# 91 — WebGPU inference backend
+
+**Status:** P2
+**Depends on:** #89
+
+## Why
+
+WebGPU gives 5-10× speedup over WASM SIMD for ONNX models:
+- Rababa: 500ms → 50ms per name in browser
+- Batch: 1000 names in ~5 seconds instead of 50
+
+onnxruntime-web supports WebGPU execution provider natively.
+
+## Approach
+
+In `src/ml/session/onnx-web.ts`:
+```typescript
+// Try WebGPU first, fall back to WASM
+try {
+  session = await ort.InferenceSession.create(data, {
+    executionProviders: ["webgpu", "wasm"],
+  })
+} catch {
+  // WebGPU not available, use WASM only
+  session = await ort.InferenceSession.create(data, {
+    executionProviders: ["wasm"],
+  })
+}
+```
+
+## Acceptance
+
+- [ ] WebGPU detected and used when available
+- [ ] Falls back to WASM seamlessly
+- [ ] 5×+ speedup on Chrome/Edge with GPU
+- [ ] No regression on Firefox (no WebGPU yet)

--- a/TODO.complete/92-item-compiler-registry.md
+++ b/TODO.complete/92-item-compiler-registry.md
@@ -1,0 +1,39 @@
+# 92 — Migrate compileItem to registry pattern
+
+**Status:** P2 (code quality)
+**Depends on:** none
+
+## Problem
+
+`src/runtime/compile-item.ts:compileItem` uses a single switch over
+Item.kind. Adding a new Item kind requires editing this switch — a
+violation of OCP.
+
+## Fix
+
+Replace the switch with a registry:
+
+```typescript
+type ItemCompiler = (item: Item, ctx: ExecutionContext) => CompiledItem
+
+const itemCompilers = new Map<Item["kind"], ItemCompiler>()
+
+export function registerItemCompiler(kind: Item["kind"], compiler: ItemCompiler): void {
+  itemCompilers.set(kind, compiler)
+}
+
+export function compileItem(item: Item, ctx: ExecutionContext): CompiledItem {
+  const compiler = itemCompilers.get(item.kind)
+  if (!compiler) throw new Error(`No compiler for Item kind: ${item.kind}`)
+  return compiler(item, ctx)
+}
+```
+
+Similarly for `compileToLiteral` and `expandFromLiterals`.
+
+## Acceptance
+
+- [ ] No switch statements on Item.kind anywhere
+- [ ] Adding a new Item kind = new file, zero edits
+- [ ] All existing tests pass unchanged
+- [ ] Type system still enforces exhaustiveness

--- a/TODO.complete/93-huggingface-hosting.md
+++ b/TODO.complete/93-huggingface-hosting.md
@@ -1,0 +1,57 @@
+# 93 — Model hosting on HuggingFace Hub
+
+**Status:** P1
+**Depends on:** #89
+
+## Why
+
+Models need a CDN for browser/HTTP loading. HuggingFace is:
+- Free for open-source
+- Global CDN
+- Standard in the ML community
+- Already used by @xenova/transformers ecosystem
+- Direct download URLs (no auth needed for public models)
+
+## Setup
+
+1. Create `huggingface.co/interscript` org
+2. Create repos:
+   - `interscript/rababa-arabic-max-len-200`
+   - `interscript/secryst-thai-ipa`
+3. Upload ONNX model + config + vocab via `huggingface-cli upload`
+4. Add README with model card (architecture, training data, license)
+5. Set `setModelBase("https://huggingface.co/interscript/interscript-models/resolve/main")`
+
+## Model card template
+
+```markdown
+---
+license: mit
+language: ar
+tags: [arabic, diacritization, onnx]
+---
+
+# Rababa Arabic Diacritization (max_len=200)
+
+## Architecture
+Tacotron CBHG seq2seq, trained on Tashkeela corpus.
+
+## Inputs
+- `src`: int64[batch, seq] — token IDs
+- `lengths`: int64[batch] — sequence lengths
+
+## Outputs
+- Predictions: float32[batch, seq, 15] — haraqat class logits
+
+## Performance
+- DER: ~5% on Tashkeela test split
+- Size: 60 MB (unquantized)
+- Latency: ~200ms/word (Node), ~500ms (WASM SIMD)
+```
+
+## Acceptance
+
+- [ ] HuggingFace org created
+- [ ] Rababa model uploaded with model card
+- [ ] Direct download URL works from interscript-ts
+- [ ] setModelBase() points at HF in production

--- a/TODO.complete/94-quantize-rababa-int8.md
+++ b/TODO.complete/94-quantize-rababa-int8.md
@@ -1,0 +1,32 @@
+# 94 — Quantize Rababa model to int8
+
+**Status:** P1
+**Depends on:** #93
+
+## Why
+
+Current model: 60 MB unquantized. int8 quantization → ~15 MB.
+4× smaller download, same accuracy. No retraining needed.
+
+## Steps
+
+```bash
+pip install onnxruntime
+
+python -m onnxruntime.quantization.quantize \
+  --input diacritization_model_max_len_200.onnx \
+  --output diacritization_model_max_len_200_int8.onnx \
+  --quant_format QDQ
+```
+
+Verify:
+- All 3 test vectors produce identical output
+- Output tensor shapes unchanged
+- Inference speed unchanged or faster
+
+## Acceptance
+
+- [ ] int8 model produced (~15 MB)
+- [ ] Test vectors match unquantized output byte-for-byte
+- [ ] Published to HuggingFace alongside the unquantized version
+- [ ] Default in provisioner (configurable via modelBase URL)

--- a/TODO.complete/95-website-ml-page.md
+++ b/TODO.complete/95-website-ml-page.md
@@ -1,0 +1,50 @@
+# 95 — Website /ml page with live demo
+
+**Status:** P1
+**Depends on:** #89, #93
+
+## Goal
+
+Add `/ml` to the website — explains ML-powered maps, shows the Rababa
+diacritizer running live in the browser. This is the public face of
+ML integration.
+
+## Layout
+
+```
+/ml (overview)
+  Hero: "Some maps need machine learning"
+  - What ML maps are vs rule-based
+  - Privacy: models run in browser, text never uploaded
+  - Architecture diagram (encoder → ONNX → reconciler)
+
+  Live demo:
+  - Input field: paste Arabic text
+  - Output: diacritized text
+  - Progress bar during model load (60MB → cached after first)
+  - System: var-ara-Arab-Arab-rababa
+
+  Comparison:
+  - Show input → diacritized → romanized (the full ML + rule pipeline)
+  - Example: قطر → قِطْرَ → Qatar (via bgnpcgn-ara-Arab-Latn-1956)
+
+  Model card link:
+  - HuggingFace badge
+  - Architecture explanation
+  - Training data source
+```
+
+## Performance
+
+- Model loads lazily only when user visits /ml
+- Service Worker caches the ONNX file
+- Web Worker for inference (reuse existing infrastructure)
+- Progress indicator during 60MB download
+
+## Acceptance
+
+- [ ] `/ml` page renders
+- [ ] Live demo works (input → output)
+- [ ] Model progress bar visible during first load
+- [ ] Subsequent visits instant (cached)
+- [ ] Privacy notice prominent

--- a/TODO.complete/96-ml-contribution-guide.md
+++ b/TODO.complete/96-ml-contribution-guide.md
@@ -1,0 +1,29 @@
+# 96 — Community: ML model contribution guide
+
+**Status:** P2
+**Depends on:** #93
+
+## Goal
+
+Document how to contribute a new ML model to Interscript. Lowers the
+barrier for linguists/ML researchers who want to add learned
+transliteration for their language.
+
+## Guide structure
+
+1. **When to use ML vs rules** — rule tables are cheaper and
+   deterministic. Only use ML when the mapping can't be captured
+   by a finite state machine (tone rules, vowel reduction, etc.)
+2. **Training data** — parallel pairs (source → target). Sources:
+   Wiktionary, published corpora, synthetic augmentation from rule maps
+3. **Model format** — ONNX export, max 100MB unquantized, ≤25MB int8
+4. **Integration** — register in `src/ml/models/<name>/`, add to manifest
+5. **Testing** — at least 10 test vectors in the map file
+6. **Hosting** — publish to HuggingFace, add to model manifest
+
+## Acceptance
+
+- [ ] `/contributing/ml` page on website
+- [ ] Template model repo on HuggingFace
+- [ ] Step-by-step with code examples
+- [ ] Link from `/contributing` main page

--- a/TODO.complete/README.md
+++ b/TODO.complete/README.md
@@ -1,0 +1,67 @@
+# TODO — Interscript Follow-Up Modernization
+
+Indexed task list for the work following the 2026-07-28 best-practices sweep.
+Each file in this directory documents one task: rationale, actions taken, status.
+
+Status legend: **DONE** · **DEFERRED** · **BLOCKED**
+
+## Priority 1 — Security (do first)
+
+| # | Task | Status |
+|---|------|--------|
+| [01](01-purge-deploy-key.md) | Purge local `deploy_key` from `interoperable-transliteration-docs` | DONE |
+| [02](02-security-md.md) | Add `SECURITY.md` to all active repos | DONE |
+| [03](03-branch-protection.md) | Branch protection on `main` for all upgraded repos | BLOCKED |
+| [04](04-dependabot-alerts.md) | Enable Dependabot security alerts per repo | DONE |
+| [05](05-oidc-trusted-publishing.md) | OIDC trusted publishing for RubyGems + npm | DEFERRED |
+
+## Priority 2 — Lint & code quality
+
+| # | Task | Status |
+|---|------|--------|
+| [06](06-standardrb-ruby-gems.md) | StandardRB in CI for all Ruby gems | DONE |
+| [07](07-eslint-interscript-js.md) | ESLint + Prettier for `interscript-js` | DONE |
+| [08](08-ruff-rababa-python.md) | ruff baseline for `rababa/python` | DONE |
+| [09](09-specs-coverage.md) | Improve spec coverage gaps | ONGOING |
+
+## Priority 3 — `interscript-api` Ruby 4.0 readiness (user request)
+
+| # | Task | Status |
+|---|------|--------|
+| [10](10-lambda-docker-ruby34.md) | Lambda Docker base 2.7 → 3.4 (Ruby 4.0-ready) | DONE |
+| [11](11-interscript-api-ruby4-ready.md) | `interscript-api` audit for Ruby 4.0 | DONE |
+| [12](12-graphql-2x.md) | GraphQL 1.x → 2.x | DEFERRED |
+| [13](13-interscript-gem-2x.md) | `interscript` 0.1.9 → 2.x in api | DEFERRED |
+| [14](14-docker-actions-replace.md) | Replace `elgohr/Publish-Docker-Github-Action` with official Docker actions | DONE |
+
+## Priority 4 — Hygiene & docs
+
+| # | Task | Status |
+|---|------|--------|
+| [15](15-contributing-md.md) | `CONTRIBUTING.md` across repos | DONE |
+| [16](16-ci-badges.md) | CI status badges in READMEs | DONE |
+| [17](17-changelog-md.md) | `CHANGELOG.md` in release repos | DONE |
+| [18](18-repo-metadata.md) | Repo metadata consistency (description, topics) | DONE |
+
+## Priority 5 — Breaking dependency upgrades
+
+| # | Task | Status |
+|---|------|--------|
+| [19](19-torch-2x.md) | `rababa/python` torch 1.9 → 2.x | DEFERRED |
+| [20](20-esm-cjs-packaging.md) | `interscript-js` dual ESM/CJS + provenance | DEFERRED |
+
+## Priority 6 — Architecture & quality
+
+| # | Task | Status |
+|---|------|--------|
+| [21](21-architectural-review.md) | OCP/MECE/DRY review of touched modules | DONE |
+| [22](22-codeql-static-analysis.md) | CodeQL workflow for Ruby + JS | DONE |
+| [23](23-ruby-deprecation-audit.md) | Ruby 4.0 deprecation audit across all gems | DONE |
+
+## Priority 7 — Multi-day efforts (separate PR series)
+
+| # | Task | Status |
+|---|------|--------|
+| [24](24-ts-runtime-port.md) | TS runtime port for `interscript-js` (Phase C2) | DEFERRED |
+| [25](25-astro-migration.md) | Astro migration for `interscript.org` (Phase G2) | DEFERRED |
+| [26](26-archive-dead-repos.md) | Archive dead repos (issue [#4](https://github.com/interscript/interscript/issues/4)) | DEFERRED |

--- a/TODO.complete/README.md
+++ b/TODO.complete/README.md
@@ -1,67 +1,62 @@
-# TODO — Interscript Follow-Up Modernization
+# TODO — Interscript Modernization
 
-Indexed task list for the work following the 2026-07-28 best-practices sweep.
-Each file in this directory documents one task: rationale, actions taken, status.
+Indexed task list for all modernization work. Each file documents one task: rationale, actions taken, status, follow-ups.
 
-Status legend: **DONE** · **DEFERRED** · **BLOCKED**
+Status legend: **DONE** · **DEFERRED** · **BLOCKED** · **TODO** · **READY**
 
-## Priority 1 — Security (do first)
+## Wave 1 — Initial best-practices sweep (2026-07-28)
 
 | # | Task | Status |
 |---|------|--------|
 | [01](01-purge-deploy-key.md) | Purge local `deploy_key` from `interoperable-transliteration-docs` | DONE |
 | [02](02-security-md.md) | Add `SECURITY.md` to all active repos | DONE |
-| [03](03-branch-protection.md) | Branch protection on `main` for all upgraded repos | BLOCKED |
+| [03](03-branch-protection.md) | Branch protection on `main` for all upgraded repos | BLOCKED → see [41](41-branch-protection-ready.md) |
 | [04](04-dependabot-alerts.md) | Enable Dependabot security alerts per repo | DONE |
 | [05](05-oidc-trusted-publishing.md) | OIDC trusted publishing for RubyGems + npm | DEFERRED |
-
-## Priority 2 — Lint & code quality
-
-| # | Task | Status |
-|---|------|--------|
 | [06](06-standardrb-ruby-gems.md) | StandardRB in CI for all Ruby gems | DONE |
 | [07](07-eslint-interscript-js.md) | ESLint + Prettier for `interscript-js` | DONE |
 | [08](08-ruff-rababa-python.md) | ruff baseline for `rababa/python` | DONE |
 | [09](09-specs-coverage.md) | Improve spec coverage gaps | ONGOING |
-
-## Priority 3 — `interscript-api` Ruby 4.0 readiness (user request)
-
-| # | Task | Status |
-|---|------|--------|
-| [10](10-lambda-docker-ruby34.md) | Lambda Docker base 2.7 → 3.4 (Ruby 4.0-ready) | DONE |
-| [11](11-interscript-api-ruby4-ready.md) | `interscript-api` audit for Ruby 4.0 | DONE |
+| [10](10-lambda-docker-ruby34.md) | Lambda Docker base 2.7 → 3.4 | DONE |
+| [11](11-interscript-api-ruby4-ready.md) | `interscript-api` Ruby 4.0 readiness | DONE |
 | [12](12-graphql-2x.md) | GraphQL 1.x → 2.x | DEFERRED |
 | [13](13-interscript-gem-2x.md) | `interscript` 0.1.9 → 2.x in api | DEFERRED |
-| [14](14-docker-actions-replace.md) | Replace `elgohr/Publish-Docker-Github-Action` with official Docker actions | DONE |
-
-## Priority 4 — Hygiene & docs
-
-| # | Task | Status |
-|---|------|--------|
+| [14](14-docker-actions-replace.md) | Replace `elgohr/Publish-Docker-Github-Action` | DONE |
 | [15](15-contributing-md.md) | `CONTRIBUTING.md` across repos | DONE |
 | [16](16-ci-badges.md) | CI status badges in READMEs | DONE |
 | [17](17-changelog-md.md) | `CHANGELOG.md` in release repos | DONE |
-| [18](18-repo-metadata.md) | Repo metadata consistency (description, topics) | DONE |
-
-## Priority 5 — Breaking dependency upgrades
-
-| # | Task | Status |
-|---|------|--------|
+| [18](18-repo-metadata.md) | Repo metadata consistency | DONE |
 | [19](19-torch-2x.md) | `rababa/python` torch 1.9 → 2.x | DEFERRED |
-| [20](20-esm-cjs-packaging.md) | `interscript-js` dual ESM/CJS + provenance | DEFERRED |
-
-## Priority 6 — Architecture & quality
-
-| # | Task | Status |
-|---|------|--------|
-| [21](21-architectural-review.md) | OCP/MECE/DRY review of touched modules | DONE |
-| [22](22-codeql-static-analysis.md) | CodeQL workflow for Ruby + JS | DONE |
-| [23](23-ruby-deprecation-audit.md) | Ruby 4.0 deprecation audit across all gems | DONE |
-
-## Priority 7 — Multi-day efforts (separate PR series)
-
-| # | Task | Status |
-|---|------|--------|
-| [24](24-ts-runtime-port.md) | TS runtime port for `interscript-js` (Phase C2) | DEFERRED |
-| [25](25-astro-migration.md) | Astro migration for `interscript.org` (Phase G2) | DEFERRED |
+| [20](20-esm-cjs-packaging.md) | `interscript-js` dual ESM/CJS + provenance | DEFERRED (superseded by interscript-ts) |
+| [21](21-architectural-review.md) | OCP/MECE/DRY review | DONE |
+| [22](22-codeql-static-analysis.md) | CodeQL workflows | DONE |
+| [23](23-ruby-deprecation-audit.md) | Ruby 4.0 deprecation audit | DONE |
+| [24](24-ts-runtime-port.md) | TS runtime port for `interscript-js` | DEFERRED (superseded by interscript-ts) |
+| [25](25-astro-migration.md) | Astro migration for `interscript.org` | DEFERRED (superseded by interscript.org-v2) |
 | [26](26-archive-dead-repos.md) | Archive dead repos (issue [#4](https://github.com/interscript/interscript/issues/4)) | DEFERRED |
+
+## Wave 2 — Merge + archive + new initiatives (2026-07-29)
+
+| # | Task | Status |
+|---|------|--------|
+| [27](27-merge-all-prs.md) | Rebase-merge all 8 upgrade PRs; close 2 opal PRs | DONE |
+| [28](28-archive-opal-repos.md) | Archive 5 opal-related repos | DONE |
+| [29](29-interscript-ts-scaffold.md) | Scaffold `interscript-ts` (TypeScript runtime) | DONE |
+| [30](30-interscript-org-v2-scaffold.md) | Scaffold `interscript.org-v2` (Astro 7 + Vue + Tailwind 4) | DONE |
+| [31](31-ruby-json-ir-compiler.md) | Ruby JSON IR compiler (enables full TS parity) | TODO |
+| [32](32-detector-implementation.md) | Detector implementation in `interscript-ts` | TODO |
+| [33](33-dsl-parser.md) | DSL parser for `.imp` files (full Ruby parity) | TODO (large) |
+| [34](34-interscript-ts-cli.md) | interscript-ts CLI | TODO |
+| [35](35-interscript-ts-publish.md) | interscript-ts npm publish + provenance | READY |
+| [36](36-port-legacy-site-content.md) | Port content from legacy site to v2 | TODO |
+| [37](37-wire-interscript-ts-to-vue.md) | Wire interscript-ts into Vue map explorer | TODO (blocked by 31) |
+| [38](38-deprecate-interscript-js.md) | Deprecate `interscript-js` in favor of `interscript-ts` | TODO (gated by v1.0) |
+| [39](39-interscript-ts-coverage.md) | Spec coverage baseline for interscript-ts | ONGOING |
+| [40](40-rename-master-to-main.md) | Rename `master` → `main` on remaining repos | TODO |
+| [41](41-branch-protection-ready.md) | Branch protection (now unblocked) | READY |
+
+## Quick links
+
+- Wave 1 plan: [docs/superpowers/plans/2026-07-28-best-practices-upgrade.md](../docs/superpowers/plans/2026-07-28-best-practices-upgrade.md)
+- Wave 2 plan: [docs/superpowers/plans/2026-07-29-follow-up-modernization.md](../docs/superpowers/plans/2026-07-29-follow-up-modernization.md)
+- Tracking issue: https://github.com/interscript/interscript/issues/4

--- a/TODO.complete/ml-modernization-research.md
+++ b/TODO.complete/ml-modernization-research.md
@@ -1,0 +1,136 @@
+# Modernization Research: ML Model Paths for Interscript (2026 SOTA)
+
+**Status:** Research note
+**Date:** 2026-07-31
+
+## Context
+
+The current ML models in Interscript were trained ~2021 using then-SOTA
+architectures (Tacotron CBHG for Rababa, vanilla transformer for Secryst).
+The field has advanced significantly. This document maps the modernization
+options.
+
+## Rababa (Arabic Diacritization)
+
+### Current state
+- Architecture: Tacotron CBHG seq2seq (2017-era)
+- Size: 60 MB ONNX (unquantized)
+- Training data: Tashkeela corpus (~3M words)
+- Performance: ~200ms/inference (Node), ~500ms (browser WASM)
+
+### Option A: ByT5-Small Fine-tune (RECOMMENDED)
+
+**Why:** Character-level T5 was designed for exactly this class of problem.
+Pretrained on multilingual text; fine-tune on diacritization data.
+
+**Size:** 300 MB unquantized → ~30 MB int8 quantized
+**Accuracy:** DER ~3% (current Tacotron: ~5-7%)
+**Inference:** ~50ms/word (quantized, SIMD)
+
+**Training plan:**
+1. Download Tashkeela++ or OpenDiacritizer dataset (~50M words)
+2. Fine-tune `google/byt5-small` via HuggingFace Transformers
+3. Export to ONNX with `optimum-exporters`
+4. Quantize to int8 via `onnxruntime` quantization tools
+5. Benchmark DER vs baseline
+
+**Tools:** HuggingFace Transformers, optimum, ONNX Runtime
+
+### Option B: Microkimi-style Mini Transformer (AMBITIOUS)
+
+**Why:** Very small transformers (1-10M params) can be distilled from
+larger models. The diacritization task is narrow enough that 5M params
+suffice.
+
+**Size:** ~5-10 MB quantized
+**Accuracy:** Likely comparable to ByT5-small (DER ~4-5%)
+**Inference:** <20ms/word in browser
+
+**Training plan:**
+1. Train baseline (ByT5-small fine-tuned — Option A)
+2. Distill into a 5M-param transformer via knowledge distillation
+3. Quantize to int4
+4. Benchmark
+
+**Tools:** PyTorch, optimum, custom distillation loop
+
+### Option C: Quantize Current Model (INTERIM — SHIP TODAY)
+
+**Why:** No retraining needed. Take the existing 60MB ONNX → int8
+quantize → ~15MB.
+
+**Size:** ~15 MB
+**Accuracy:** Same as current (quantization-aware inference)
+**Inference:** Same latency, 4× smaller download
+
+**Steps:**
+1. `python -m onnxruntime.quantization.quantize --input model.onnx --output model-int8.onnx --quant_format QDQ`
+2. Verify outputs match (byte-for-byte on test vectors)
+3. Publish as `rababa/200/int8`
+
+## Secryst (Learned Transliteration)
+
+### Current state
+- Architecture: Vanilla seq2seq transformer
+- Active model: Thai → IPA (trained on Wiktionary)
+- No quantization
+
+### Option A: ByT5 Fine-tune
+
+Same pattern as Rababa Option A. ByT5 is character-level → no tokenization
+issues. Pretrained on multilingual text including Thai.
+
+### Option B: Shared Multilingual Backbone
+
+If multiple secryst maps emerge (Thai, Khmer, Amharic):
+1. Train a shared multilingual transliteration backbone
+2. Fine-tune per task via LoRA
+3. Each task adds <1MB of LoRA weights on top of the shared model
+
+This is the NLLB pattern, applied to transliteration.
+
+### Option C: Mamba / State Space Model
+
+For very long sequences (paragraphs of Thai), linear-time Mamba beats
+transformer's quadratic attention. Worth benchmarking but probably
+overkill for single-name transliteration.
+
+## Cross-cutting: Browser Deployment
+
+### Quantization
+- int8: standard for 2026. 4× size reduction, ~2% accuracy loss.
+- int4: bleeding edge. 8× reduction, ~5% accuracy loss.
+- Recommended: int8 for production.
+
+### WebGPU
+- onnxruntime-web supports WebGPU execution provider
+- 5-10× faster than WASM SIMD on supported GPUs
+- Currently ~60% browser support (Chrome, Edge, Safari 17+)
+- Progressive enhancement: try WebGPU, fall back to WASM
+
+### Model Caching
+- Service Worker caches ONNX files after first download
+- IndexedDB for models > 5MB (localStorage has 5MB limit)
+- Manifest with SHA256 verification for integrity
+
+## Recommended Path
+
+1. **Immediate (this PR):** Ship current Rababa ONNX via the new ML
+   abstraction layer. Works, just heavy.
+2. **Short term (2 weeks):** Quantize to int8 (Option C). 15MB model,
+   same accuracy.
+3. **Medium term (1 month):** Train ByT5-small (Option A). 30MB, better
+   accuracy.
+4. **Research arc:** Evaluate mini-transformer distillation (Option B)
+   and shared backbone for secryst.
+
+## References
+
+- ByT5: Xue et al., 2022. "ByT5: Towards a Token-Free Future with
+  Pre-trained Byte-to-Byte Models"
+- Tashkeela: Azhari et al., 2016. "Tashkeela: Novel corpus of Arabic
+  vocalized texts for automatic diacritization"
+- OpenDiacritizer: AlKhamissi et al., 2021
+- microkimi: https://github.com/serphen/microkimi (tiny transformer training)
+- onnxruntime quantization:
+  https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html

--- a/TODO.complete/ml-modernization-research.md
+++ b/TODO.complete/ml-modernization-research.md
@@ -1,136 +1,86 @@
 # Modernization Research: ML Model Paths for Interscript (2026 SOTA)
 
-**Status:** Research note
+**Status:** Research note — REVISED
 **Date:** 2026-07-31
+**Key insight:** Quantization is NOT the path. Train a better model.
 
-## Context
+## Why quantization is wrong
 
-The current ML models in Interscript were trained ~2021 using then-SOTA
-architectures (Tacotron CBHG for Rababa, vanilla transformer for Secryst).
-The field has advanced significantly. This document maps the modernization
-options.
+Quantizing the current Tacotron CBHG makes it smaller but doesn't fix
+its fundamental problem: it's a 2021-era architecture designed for
+text-to-speech, repurposed for diacritization. Even at full precision,
+its DER (diacritization error rate) is ~5-7%. A modern architecture
+trained from pretraining achieves ~2-3% — better accuracy, not just
+smaller size.
 
-## Rababa (Arabic Diacritization)
+The correct path: **train a new model with a better architecture**.
 
-### Current state
-- Architecture: Tacotron CBHG seq2seq (2017-era)
-- Size: 60 MB ONNX (unquantized)
-- Training data: Tashkeela corpus (~3M words)
-- Performance: ~200ms/inference (Node), ~500ms (browser WASM)
+## Rababa (Arabic Diacritization) — Recommended Path
 
-### Option A: ByT5-Small Fine-tune (RECOMMENDED)
+### ByT5-small fine-tune (PRIMARY)
 
-**Why:** Character-level T5 was designed for exactly this class of problem.
-Pretrained on multilingual text; fine-tune on diacritization data.
+**Why ByT5:**
+- Character-level: no tokenization, no vocab mismatch. Every byte
+  is a token. Arabic chars, haraqat, punctuation — all handled
+  natively.
+- Pretrained on multilingual text: the model already "knows" Arabic
+  letter shapes and bigram frequencies before fine-tuning.
+- Fine-tuning for diacritization takes hours, not days.
+- SOTA on Arabic DER benchmarks (every recent paper uses T5/ByT5).
 
-**Size:** 300 MB unquantized → ~30 MB int8 quantized
-**Accuracy:** DER ~3% (current Tacotron: ~5-7%)
-**Inference:** ~50ms/word (quantized, SIMD)
+**Architecture:**
+```
+Input:  "قطر" (raw bytes)
+  → ByT5 encoder (12 layers, 2096 hidden)
+  → ByT5 decoder (4 layers, 2096 hidden)
+Output: "قِطْرَ" (raw bytes with haraqat inserted)
+```
 
-**Training plan:**
-1. Download Tashkeela++ or OpenDiacritizer dataset (~50M words)
-2. Fine-tune `google/byt5-small` via HuggingFace Transformers
-3. Export to ONNX with `optimum-exporters`
-4. Quantize to int8 via `onnxruntime` quantization tools
-5. Benchmark DER vs baseline
+**Training:**
+1. `pip install transformers datasets accelerate`
+2. Load `google/byt5-small` from HuggingFace
+3. Fine-tune on Tashkeela++ (cleaned + deduplicated, ~50M words)
+4. Also add synthetic augmentation from OpenDiacritizer
+5. Evaluate on held-out test set
+6. Export to ONNX: `optimum-cli export onnx --model ./byt5-rababa ./rababa-byt5-onnx`
 
-**Tools:** HuggingFace Transformers, optimum, ONNX Runtime
+**Expected:**
+- DER: ~2-3% (vs current 5-7%)
+- Size: ~120 MB (ByT5-small is 300M params)
+- Latency: ~100ms/word (Node), ~300ms (browser WASM)
 
-### Option B: Microkimi-style Mini Transformer (AMBITIOUS)
+### Distillation into mini-model (BROWSER-GRADE)
 
-**Why:** Very small transformers (1-10M params) can be distilled from
-larger models. The diacritization task is narrow enough that 5M params
-suffice.
+1. Use ByT5 teacher to label a large corpus
+2. Train a small (4-layer, 256-hidden) student
+3. ~5-10 MB, DER ~3-4%, <20ms/word in browser
+- Small enough to bundle in the website by default
 
-**Size:** ~5-10 MB quantized
-**Accuracy:** Likely comparable to ByT5-small (DER ~4-5%)
-**Inference:** <20ms/word in browser
+## Secryst (Learned Transliteration) — Same Path
 
-**Training plan:**
-1. Train baseline (ByT5-small fine-tuned — Option A)
-2. Distill into a 5M-param transformer via knowledge distillation
-3. Quantize to int4
-4. Benchmark
+### ByT5 fine-tune for Thai → IPA
 
-**Tools:** PyTorch, optimum, custom distillation loop
+1. Start from `google/byt5-small`
+2. Fine-tune on Wiktionary Thai-IPA pairs
+3. Leverages multilingual pretraining
+4. Export to ONNX
 
-### Option C: Quantize Current Model (INTERIM — SHIP TODAY)
+## Implementation plan
 
-**Why:** No retraining needed. Take the existing 60MB ONNX → int8
-quantize → ~15MB.
-
-**Size:** ~15 MB
-**Accuracy:** Same as current (quantization-aware inference)
-**Inference:** Same latency, 4× smaller download
-
-**Steps:**
-1. `python -m onnxruntime.quantization.quantize --input model.onnx --output model-int8.onnx --quant_format QDQ`
-2. Verify outputs match (byte-for-byte on test vectors)
-3. Publish as `rababa/200/int8`
-
-## Secryst (Learned Transliteration)
-
-### Current state
-- Architecture: Vanilla seq2seq transformer
-- Active model: Thai → IPA (trained on Wiktionary)
-- No quantization
-
-### Option A: ByT5 Fine-tune
-
-Same pattern as Rababa Option A. ByT5 is character-level → no tokenization
-issues. Pretrained on multilingual text including Thai.
-
-### Option B: Shared Multilingual Backbone
-
-If multiple secryst maps emerge (Thai, Khmer, Amharic):
-1. Train a shared multilingual transliteration backbone
-2. Fine-tune per task via LoRA
-3. Each task adds <1MB of LoRA weights on top of the shared model
-
-This is the NLLB pattern, applied to transliteration.
-
-### Option C: Mamba / State Space Model
-
-For very long sequences (paragraphs of Thai), linear-time Mamba beats
-transformer's quadratic attention. Worth benchmarking but probably
-overkill for single-name transliteration.
-
-## Cross-cutting: Browser Deployment
-
-### Quantization
-- int8: standard for 2026. 4× size reduction, ~2% accuracy loss.
-- int4: bleeding edge. 8× reduction, ~5% accuracy loss.
-- Recommended: int8 for production.
-
-### WebGPU
-- onnxruntime-web supports WebGPU execution provider
-- 5-10× faster than WASM SIMD on supported GPUs
-- Currently ~60% browser support (Chrome, Edge, Safari 17+)
-- Progressive enhancement: try WebGPU, fall back to WASM
-
-### Model Caching
-- Service Worker caches ONNX files after first download
-- IndexedDB for models > 5MB (localStorage has 5MB limit)
-- Manifest with SHA256 verification for integrity
-
-## Recommended Path
-
-1. **Immediate (this PR):** Ship current Rababa ONNX via the new ML
-   abstraction layer. Works, just heavy.
-2. **Short term (2 weeks):** Quantize to int8 (Option C). 15MB model,
-   same accuracy.
-3. **Medium term (1 month):** Train ByT5-small (Option A). 30MB, better
-   accuracy.
-4. **Research arc:** Evaluate mini-transformer distillation (Option B)
-   and shared backbone for secryst.
+| Step | What | Effort | Timeline |
+|------|------|--------|----------|
+| 1 | Set up training env (GPU) | 1 day | Week 1 |
+| 2 | Clean Tashkeela++ + augmentation | 2 days | Week 1 |
+| 3 | Fine-tune ByT5-small on Arabic | 1 day | Week 1 |
+| 4 | Evaluate DER | 0.5 day | Week 1 |
+| 5 | Export to ONNX + publish | 0.5 day | Week 1 |
+| 6 | Integrate into interscript-ts | 1 day | Week 2 |
+| 7 | Distill into mini-model | 2 days | Week 2-3 |
+| 8 | Fine-tune for Thai-IPA | 1 day | Week 3 |
 
 ## References
 
-- ByT5: Xue et al., 2022. "ByT5: Towards a Token-Free Future with
-  Pre-trained Byte-to-Byte Models"
-- Tashkeela: Azhari et al., 2016. "Tashkeela: Novel corpus of Arabic
-  vocalized texts for automatic diacritization"
-- OpenDiacritizer: AlKhamissi et al., 2021
-- microkimi: https://github.com/serphen/microkimi (tiny transformer training)
-- onnxruntime quantization:
-  https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html
+- ByT5: Xue et al., 2022
+- microkimi: https://github.com/serphen/microkimi
+- NLLB: Costa-jussà et al., 2022 (shared backbone)
+- Distillation: Hinton et al., 2015; Sanh et al., 2019 (DistilBERT)

--- a/TODO.rababa/00-repository-specification.md
+++ b/TODO.rababa/00-repository-specification.md
@@ -1,0 +1,105 @@
+# rababa-v2: 00 — Repository specification
+
+**Status:** SPECIFICATION
+**Priority:** P0 (first thing to create)
+
+## Repository
+
+```
+github.com/interscript/rababa-v2
+```
+
+Separate repo from the Ruby gem. The Ruby gem stays as the legacy
+runtime; rababa-v2 is the training + export pipeline that produces
+ONNX models consumed by interscript-ts.
+
+## Structure (ML project best practices)
+
+```
+rababa-v2/
+├── README.md                     # What this is, how to reproduce
+├── pyproject.toml                # Python deps (uv or poetry)
+├── .gitignore                    # data/, models/, __pycache__/, *.onnx
+├── .gitattributes                # Git-LFS for .onnx, .safetensors
+├── LICENSE                       # MIT (model weights: see model_card)
+│
+├── data/                         # gitignored — fetched via scripts/
+│   ├── raw/                      # Original Tashkeela++ download
+│   ├── processed/                # Cleaned + deduplicated
+│   └── augmented/                # Synthetic labels from teacher
+│
+├── src/
+│   ├── data/                     # Data pipeline (OCP: each step = one module)
+│   │   ├── __init__.py
+│   │   ├── download.py           # Fetch Tashkeela++ + OpenDiacritizer
+│   │   ├── clean.py              # Strip OCR noise, deduplicate, validate
+│   │   ├── encode.py             # Character-level encoding for ByT5
+│   │   └── augment.py            # Synthetic data via teacher predictions
+│   │
+│   ├── models/                   # Model definitions (MECE: one file per arch)
+│   │   ├── __init__.py
+│   │   ├── teacher_llm.py        # Nemotron-Mini / Phi-3 fine-tune wrapper
+│   │   ├── teacher_byt5.py       # ByT5-small fine-tune (alternative teacher)
+│   │   └── student.py            # Mini transformer for distillation
+│   │
+│   ├── training/                 # Training loops (DRY: shared base class)
+│   │   ├── __init__.py
+│   │   ├── base.py               # BaseTrainer: epoch loop, checkpointing
+│   │   ├── finetune.py           # FineTuneTrainer(BaseTrainer)
+│   │   ├── distill.py            # DistillTrainer(BaseTrainer)
+│   │   └── evaluate.py           # DER / WER metrics
+│   │
+│   └── export/                   # ONNX export for interscript-ts
+│       ├── __init__.py
+│       ├── onnx_export.py        # PyTorch → ONNX
+│       └── verify.py             # Verify ONNX output matches PyTorch
+│
+├── scripts/
+│   ├── setup_env.sh              # Create venv, install deps
+│   ├── fetch_data.sh             # Download all datasets
+│   ├── train_teacher.sh          # Full teacher training pipeline
+│   ├── train_student.sh          # Full distillation pipeline
+│   ├── benchmark.sh              # Run DER + latency benchmarks
+│   └── publish.sh                # Upload to HuggingFace Hub
+│
+├── configs/
+│   ├── teacher_nemotron.yaml     # Nemotron-Mini hyperparams
+│   ├── teacher_byt5.yaml         # ByT5-small hyperparams
+│   ├── student.yaml              # Student model hyperparams
+│   └── data.yaml                 # Data pipeline config
+│
+├── tests/
+│   ├── test_data.py              # Data cleaning + encoding
+│   ├── test_models.py            # Model forward pass
+│   ├── test_der.py               # DER metric calculation
+│   └── test_onnx.py              # ONNX export verification
+│
+├── notebooks/
+│   ├── eda.ipynb                 # Exploratory data analysis
+│   └── error_analysis.ipynb      # Where does the model fail?
+│
+└── docs/
+    ├── model_card.md             # HuggingFace model card template
+    ├── training_log.md           # Experiment log (dates, params, DER)
+    └── architecture.md           # Why LLM, not Tacotron
+```
+
+## Why a separate repo
+
+- **Clean separation of concerns**: the Ruby gem is a runtime; this is
+  a training pipeline. Mixing Python training code into a Ruby gem is
+  confusing.
+- **Different CI**: Python tests vs Ruby specs, GPU vs CPU runners.
+- **Different deps**: PyTorch + transformers vs Ruby + onnx-runtime.
+- **Reproducibility**: the repo is self-contained. Anyone can clone +
+  `scripts/setup_env.sh && scripts/train_teacher.sh` to reproduce.
+
+## Git-LFS
+
+Models (.onnx, .safetensors) are tracked via Git-LFS:
+```bash
+git lfs install
+git lfs track "*.onnx" "*.safetensors" "*.ckpt"
+```
+
+Training data is NOT committed (too large). Fetched via `scripts/fetch_data.sh`.

--- a/TODO.rababa/01-data-pipeline.md
+++ b/TODO.rababa/01-data-pipeline.md
@@ -1,0 +1,65 @@
+# rababa-v2: 01 — Data pipeline
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+Build a clean, reproducible data pipeline that produces training-ready
+datasets for Arabic diacritization.
+
+## Sources
+
+### Primary: Tashkeela++
+- ~50M Arabic words with full diacritization
+- Cleaned version of the original Tashkeela corpus
+- Source: https://huggingface.co/datasets (search "tashkeela")
+- Format: tab-separated (undiacritized | diacritized)
+
+### Secondary: OpenDiacritizer corpus
+- ~2M sentences from Arabic Wikipedia + news
+- Automatically diacritized (silver labels)
+- Source: https://github.com/almodhfer/OpenDiacritizer
+
+### Synthetic augmentation
+- Take undiacritized Arabic from large corpora (CC-100, OSCAR)
+- Run the teacher model to generate silver labels
+- Mix gold (Tashkeela++) + silver 60/40
+
+## Pipeline stages
+
+```
+download.py   →  raw data in data/raw/
+     ↓
+clean.py      →  validated pairs in data/processed/
+     ↓
+encode.py     →  tokenized tensors in data/processed/*.pt
+     ↓
+augment.py    →  silver-labeled data in data/augmented/
+```
+
+### clean.py rules
+- Remove entries with non-Arabic characters (keep haraqat + basic punctuation)
+- Remove entries shorter than 3 chars or longer than 200 chars
+- Deduplicate by (input, output) pair
+- Validate: stripped input + haraqat ≈ output (consistency check)
+- Split: 90% train, 5% validation, 5% test (deterministic seed)
+
+### encode.py
+
+For LLM teachers (Nemotron/Phi-3):
+- Use the model's native tokenizer
+- Format as chat/instruction: "Add harakat to the following Arabic text: {input}"
+- Target: the diacritized text
+
+For ByT5 teacher:
+- Character-level: every byte is a token
+- No special formatting needed
+
+## Acceptance
+
+- [ ] `scripts/fetch_data.sh` downloads all sources
+- [ ] `src/data/clean.py` produces deduplicated, validated splits
+- [ ] `src/data/encode.py` produces tokenized tensors
+- [ ] `tests/test_data.py` verifies data integrity
+- [ ] DER baseline computed on cleaned Tashkeela++ test split

--- a/TODO.rababa/02-teacher-model.md
+++ b/TODO.rababa/02-teacher-model.md
@@ -1,6 +1,6 @@
-# rababa-v2: 02 — Teacher model (Nemotron-Mini / Phi-3 fine-tune)
+# rababa-v2: 02 — Teacher model (Qwen3.5-4B fine-tune)
 
-**Status:** SPECIFICATION
+**Status:** SPECIFICATION (updated 2026-08-01 — verified latest HuggingFace models)
 **Priority:** P0
 
 ## Why an LLM, not Tacotron
@@ -10,95 +10,40 @@ architecture repurposed for text. Its inductive biases (convolution
 banks for acoustic features, attention for audio alignment) are wrong
 for a pure text task.
 
-A modern small LLM (Nemotron-Mini, Phi-3-mini, Gemma-2-2B) already
-understands Arabic morphology from pretraining:
+A modern Qwen LLM already understands Arabic morphology from pretraining:
 - Root patterns (جذر): ق-ط-ر, ك-ت-ب, د-ر-س
 - Context-dependent vowel selection (same consonants → different
   haraqat based on meaning)
 - Morphological rules (definite article ال, sun letters, etc.)
 
-Diacritization is: "given these consonants + context, predict vowels."
-That's exactly what a language model does.
+## Teacher candidates (August 2026 — verified on HuggingFace)
 
-## Teacher candidates (2026)
+| Model | Params | Downloads | Why |
+|---|---|---|---|
+| **Qwen3.5-4B** | 4B | 6.3M | Latest dense Qwen. Strong Arabic. LoRA on A100. |
+| Qwen3-1.7B | 1.7B | 7.5M | Smaller, faster iteration. Consumer GPU (RTX 4090). |
+| Qwen3-4B-Instruct-2507 | 4B | 3.3M | Instruction-tuned. Can prompt zero-shot before fine-tuning. |
+| Qwen3.6-35B-A3B | 35B/3B active | 6.1M | MoE — 3B active, very efficient inference. Multi-GPU for training. |
+| Qwen2.5-3B-Instruct | 3B | 5.8M | Previous gen. Battle-tested ONNX export. |
 
-| Model | Params | Arabic pretraining | License | Inference |
-|---|---|---|---|---|
-| **Nemotron-Mini-4B** | 4B | Yes (NVIDIA multilingual) | NVIDIA Open | NeMo / vLLM |
-| **Phi-3-mini-4K** | 3.8B | Moderate | MIT | ONNX export native |
-| **Gemma-2-2B** | 2B | Yes (Google multilingual) | Gemma License | TFLite / ONNX |
-| **Qwen2.5-3B** | 3B | Yes (strong Arabic) | Apache 2.0 | vLLM / ONNX |
+**Primary: Qwen3.5-4B** — best Arabic understanding at a trainable size.
+**Fallback: Qwen3-1.7B** — faster iteration, consumer GPU.
 
-**Recommended: Qwen2.5-3B or Gemma-2-2B** — strongest Arabic understanding
-at ≤3B params. Both export cleanly to ONNX.
-
-**Alternative: Nemotron-Mini-4B** — if NVIDIA NeMo pipeline is preferred.
-
-## Fine-tuning approach
+## Fine-tuning
 
 ```python
 # src/models/teacher_llm.py
-from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
-from peft import LoraConfig, get_peft_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model, TaskType
 
-model_name = "Qwen/Qwen2.5-3B"  # or "google/gemma-2-2b"
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-model = AutoModelForCausalLM.from_pretrained(model_name)
-
-# LoRA: train only 0.5% of params (fast, memory-efficient)
-lora_config = LoraConfig(
-    task_type="CAUSAL_LM",
-    r=16,
-    lora_alpha=32,
-    target_modules=["q_proj", "v_proj", "k_proj", "o_proj"],
+model = AutoModelForCausalLM.from_pretrained(
+    "Qwen/Qwen3.5-4B", torch_dtype="auto", device_map="auto",
 )
-model = get_peft_model(model, lora_config)
-
-# Training prompt format:
-# "Add full harakat (diacritics) to this Arabic text:\nقطر\n---\nقِطْرَ"
-# The model learns to generate the diacritized form.
+model = get_peft_model(model, LoraConfig(
+    task_type=TaskType.CAUSAL_LM, r=16, lora_alpha=32,
+    target_modules=["q_proj","v_proj","k_proj","o_proj","gate_proj","up_proj","down_proj"],
+    lora_dropout=0.05,
+))
 ```
 
-### Fine-tune config (configs/teacher_qwen.yaml)
-
-```yaml
-model: Qwen/Qwen2.5-3B
-method: lora
-lora:
-  r: 16
-  alpha: 32
-  dropout: 0.05
-training:
-  epochs: 3
-  batch_size: 16
-  gradient_accumulation: 4
-  learning_rate: 2e-4
-  warmup_steps: 100
-  fp16: true
-data:
-  train_split: data/processed/train.jsonl
-  val_split: data/processed/val.jsonl
-  max_length: 512
-output: models/teacher-qwen-rababa/
-```
-
-## Evaluation
-
-```python
-# src/training/evaluate.py
-def der(predicted: str, gold: str) -> float:
-    """Diacritization Error Rate: fraction of incorrectly predicted haraqat."""
-    # Align by character (strip non-haraqat for alignment)
-    # Count mismatches in haraqat positions
-    ...
-
-# Target: DER < 3% on Tashkeela++ test split
-```
-
-## Acceptance
-
-- [ ] Fine-tuning script runs end-to-end on single A100
-- [ ] DER < 3% on Tashkeela++ test split
-- [ ] All 3 test vectors from var-ara-Arab-Arab-rababa.imp pass
-- [ ] Model checkpoint saved to `models/teacher-qwen-rababa/`
-- [ ] Training log documents: epochs, learning rate, DER curve
+Config: `configs/teacher_qwen35.yaml` → Qwen3.5-4B, LoRA r=16, bf16, 3 epochs.

--- a/TODO.rababa/02-teacher-model.md
+++ b/TODO.rababa/02-teacher-model.md
@@ -1,0 +1,104 @@
+# rababa-v2: 02 — Teacher model (Nemotron-Mini / Phi-3 fine-tune)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Why an LLM, not Tacotron
+
+The current Rababa uses a Tacotron CBHG — a **speech synthesis**
+architecture repurposed for text. Its inductive biases (convolution
+banks for acoustic features, attention for audio alignment) are wrong
+for a pure text task.
+
+A modern small LLM (Nemotron-Mini, Phi-3-mini, Gemma-2-2B) already
+understands Arabic morphology from pretraining:
+- Root patterns (جذر): ق-ط-ر, ك-ت-ب, د-ر-س
+- Context-dependent vowel selection (same consonants → different
+  haraqat based on meaning)
+- Morphological rules (definite article ال, sun letters, etc.)
+
+Diacritization is: "given these consonants + context, predict vowels."
+That's exactly what a language model does.
+
+## Teacher candidates (2026)
+
+| Model | Params | Arabic pretraining | License | Inference |
+|---|---|---|---|---|
+| **Nemotron-Mini-4B** | 4B | Yes (NVIDIA multilingual) | NVIDIA Open | NeMo / vLLM |
+| **Phi-3-mini-4K** | 3.8B | Moderate | MIT | ONNX export native |
+| **Gemma-2-2B** | 2B | Yes (Google multilingual) | Gemma License | TFLite / ONNX |
+| **Qwen2.5-3B** | 3B | Yes (strong Arabic) | Apache 2.0 | vLLM / ONNX |
+
+**Recommended: Qwen2.5-3B or Gemma-2-2B** — strongest Arabic understanding
+at ≤3B params. Both export cleanly to ONNX.
+
+**Alternative: Nemotron-Mini-4B** — if NVIDIA NeMo pipeline is preferred.
+
+## Fine-tuning approach
+
+```python
+# src/models/teacher_llm.py
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+from peft import LoraConfig, get_peft_model
+
+model_name = "Qwen/Qwen2.5-3B"  # or "google/gemma-2-2b"
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+model = AutoModelForCausalLM.from_pretrained(model_name)
+
+# LoRA: train only 0.5% of params (fast, memory-efficient)
+lora_config = LoraConfig(
+    task_type="CAUSAL_LM",
+    r=16,
+    lora_alpha=32,
+    target_modules=["q_proj", "v_proj", "k_proj", "o_proj"],
+)
+model = get_peft_model(model, lora_config)
+
+# Training prompt format:
+# "Add full harakat (diacritics) to this Arabic text:\nقطر\n---\nقِطْرَ"
+# The model learns to generate the diacritized form.
+```
+
+### Fine-tune config (configs/teacher_qwen.yaml)
+
+```yaml
+model: Qwen/Qwen2.5-3B
+method: lora
+lora:
+  r: 16
+  alpha: 32
+  dropout: 0.05
+training:
+  epochs: 3
+  batch_size: 16
+  gradient_accumulation: 4
+  learning_rate: 2e-4
+  warmup_steps: 100
+  fp16: true
+data:
+  train_split: data/processed/train.jsonl
+  val_split: data/processed/val.jsonl
+  max_length: 512
+output: models/teacher-qwen-rababa/
+```
+
+## Evaluation
+
+```python
+# src/training/evaluate.py
+def der(predicted: str, gold: str) -> float:
+    """Diacritization Error Rate: fraction of incorrectly predicted haraqat."""
+    # Align by character (strip non-haraqat for alignment)
+    # Count mismatches in haraqat positions
+    ...
+
+# Target: DER < 3% on Tashkeela++ test split
+```
+
+## Acceptance
+
+- [ ] Fine-tuning script runs end-to-end on single A100
+- [ ] DER < 3% on Tashkeela++ test split
+- [ ] All 3 test vectors from var-ara-Arab-Arab-rababa.imp pass
+- [ ] Model checkpoint saved to `models/teacher-qwen-rababa/`
+- [ ] Training log documents: epochs, learning rate, DER curve

--- a/TODO.rababa/03-student-model.md
+++ b/TODO.rababa/03-student-model.md
@@ -1,0 +1,112 @@
+# rababa-v2: 03 — Student model (distillation for browser)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+Distill the teacher (2-4B params, ~4-8 GB) into a student small enough
+to load in a browser WASM runtime: 5-10M params, ~5-10 MB ONNX.
+
+## Architecture
+
+Character-level encoder-decoder transformer (not an LLM):
+
+```python
+# src/models/student.py
+import torch.nn as nn
+
+class StudentDiacritizer(nn.Module):
+    """Mini transformer for character-level diacritization.
+    ~5-8M params. Maps input bytes → output bytes with haraqat inserted.
+    """
+    def __init__(self, vocab_size=256, d_model=256, nhead=4,
+                 num_layers=4, dim_ff=1024, max_len=256):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, d_model)
+        self.pos_encoding = nn.Parameter(torch.randn(max_len, d_model) * 0.02)
+        self.transformer = nn.Transformer(
+            d_model=d_model, nhead=nhead,
+            num_encoder_layers=num_layers,
+            num_decoder_layers=num_layers,
+            dim_feedforward=dim_ff,
+            dropout=0.1,
+            batch_first=True,
+        )
+        self.output = nn.Linear(d_model, vocab_size)
+
+    def forward(self, src, tgt, src_mask, tgt_mask, src_key_padding_mask, tgt_key_padding_mask):
+        src = self.embedding(src) + self.pos_encoding[:src.size(1)]
+        tgt = self.embedding(tgt) + self.pos_encoding[:tgt.size(1)]
+        out = self.transformer(src, tgt, src_mask, tgt_mask, None,
+                               src_key_padding_mask, tgt_key_padding_mask)
+        return self.output(out)
+```
+
+**Size: ~6M params × 4 bytes = 24 MB unquantized → 6 MB int8.**
+
+## Distillation process
+
+```python
+# src/training/distill.py
+
+# 1. Teacher generates labels for a large corpus of undiacritized Arabic
+teacher_labels = teacher_model.generate(large_corpus)
+
+# 2. Student learns from teacher's labels (knowledge distillation)
+student_loss = cross_entropy(student_logits, teacher_labels) \
+             + KL_divergence(student_softmax, teacher_softmax, T=2.0)
+```
+
+The student learns the teacher's output distribution, not just the argmax.
+This gives it softer training signal → better generalization on rare
+patterns.
+
+## Student training config (configs/student.yaml)
+
+```yaml
+architecture:
+  vocab_size: 256          # UTF-8 byte-level
+  d_model: 256
+  nhead: 4
+  num_layers: 4
+  dim_feedforward: 1024
+  max_len: 256
+  dropout: 0.1
+  params_estimate: 6_000_000
+
+training:
+  epochs: 50
+  batch_size: 64
+  learning_rate: 3e-4
+  warmup_steps: 1000
+  scheduler: cosine
+  label_smoothing: 0.1
+  teacher_temperature: 2.0
+  teacher_weight: 0.7     # weight for KL divergence vs hard labels
+
+data:
+  teacher_labels: data/augmented/teacher_labels.jsonl
+  gold_labels: data/processed/train.jsonl
+  max_length: 200
+
+output: models/student-rababa/
+```
+
+## Expected results
+
+| Metric | Teacher | Student | Current Tacotron |
+|---|---|---|---|
+| DER | 1-2% | 3-4% | 5-7% |
+| Size | 4-8 GB | 6 MB | 60 MB |
+| Browser latency | N/A | ~20ms | ~500ms |
+| Node latency | ~100ms | ~5ms | ~200ms |
+
+## Acceptance
+
+- [ ] Student architecture implemented in PyTorch
+- [ ] Distillation loop runs end-to-end
+- [ ] DER < 4% on Tashkeela++ test split
+- [ ] ONNX export produces <10 MB file
+- [ ] ONNX model loads in interscript-ts via onnxruntime-web
+- [ ] Browser inference <30ms per word

--- a/TODO.rababa/04-onnx-export-integration.md
+++ b/TODO.rababa/04-onnx-export-integration.md
@@ -1,0 +1,87 @@
+# rababa-v2: 04 — ONNX export + interscript-ts integration
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+Export the trained student model to ONNX format, verify it loads in
+interscript-ts, and update the ML module to use it.
+
+## Export pipeline
+
+```python
+# src/export/onnx_export.py
+import torch
+from optimum.onnxruntime import ORTModelForSeq2SeqLM
+from src.models.student import StudentDiacritizer
+
+model = StudentDiacritizer()
+model.load_state_dict(torch.load("models/student-rababa/best.pt"))
+model.eval()
+
+# Create dummy input for tracing
+dummy_src = torch.randint(0, 256, (1, 200), dtype=torch.long)
+dummy_tgt = torch.randint(0, 256, (1, 10), dtype=torch.long)
+dummy_masks = ...
+
+# Export
+torch.onnx.export(
+    model,
+    (dummy_src, dummy_tgt, *dummy_masks),
+    "models/student-rababa/student.onnx",
+    input_names=["src", "tgt", "src_mask", "tgt_mask",
+                 "src_key_padding_mask", "tgt_key_padding_mask"],
+    output_names=["logits"],
+    dynamic_axes={
+        "src": {0: "batch", 1: "seq"},
+        "tgt": {0: "batch", 1: "seq"},
+        "logits": {0: "batch", 1: "seq"},
+    },
+    opset_version=17,
+)
+```
+
+## Verification
+
+```python
+# src/export/verify.py
+# Run the same input through both PyTorch and ONNX, compare outputs
+# Max absolute difference must be < 1e-4
+```
+
+## interscript-ts integration
+
+The student is a seq2seq transformer (like Secryst). Integration:
+1. The ONNX model's input/output names match the Secryst session interface
+2. Register as a new model kind: `rababa-llm` (distinct from legacy
+   `rababa` Tacotron)
+3. The ML module auto-detects which model to use based on map config
+
+```typescript
+// src/ml/models/rababa-llm/index.ts
+registerModel("rababa-llm", async (params) => {
+  // Same autoregressive decode as Secryst, but byte-level
+  const session = params.session
+  const decoder = new ByteLevelDecoder(session)
+  return new RababaLLMModel(session, decoder)
+})
+```
+
+## Backward compatibility
+
+The legacy `rababa` (Tacotron) stays registered for users who want it.
+Maps can specify which model:
+```ruby
+# In the .imp file:
+rababa config: "200"              # legacy Tacotron (default)
+rababa config: "200", model: "llm"  # new LLM-distilled student
+```
+
+## Acceptance
+
+- [ ] ONNX export script produces a valid model file
+- [ ] PyTorch ↔ ONNX output difference < 1e-4
+- [ ] interscript-ts loads the ONNX via onnxruntime-node
+- [ ] All 3 test vectors from var-ara-Arab-Arab-rababa.imp pass
+- [ ] No regression in non-ML maps

--- a/TODO.rababa/05-evaluation-benchmark.md
+++ b/TODO.rababa/05-evaluation-benchmark.md
@@ -1,0 +1,69 @@
+# rababa-v2: 05 — Evaluation + benchmark suite
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+Comprehensive evaluation harness comparing:
+- Legacy Tacotron (current baseline)
+- LLM teacher (Nemotron/Phi-3/Qwen fine-tune)
+- Distilled student (browser-grade)
+- Ruby Rababa (reference implementation)
+
+## Metrics
+
+### DER (Diacritization Error Rate)
+Primary metric. Fraction of haraqat positions predicted incorrectly.
+Lower is better. Industry SOTA: ~2%.
+
+### WER (Word Error Rate)
+Fraction of words with at least one wrong haraqat.
+More user-relevant than DER (a word is "wrong" if any haraqat is off).
+
+### Latency
+- Node: `onnxruntime-node` inference time per word
+- Browser: `onnxruntime-web` WASM SIMD time per word
+- Browser (WebGPU): same with WebGPU execution provider
+
+### Size
+ONNX file size (unquantized). Lower is better for browser deployment.
+
+## Benchmark datasets
+
+| Dataset | Size | Purpose |
+|---|---|---|
+| Tashkeela++ test split | ~25K words | Primary DER benchmark |
+| var-ara-Arab-Arab-rababa.imp test vectors | 3 vectors | Integration test |
+| Arabic Wikipedia sample | 1K sentences | Real-world text |
+| News articles (Al Jazeera) | 500 articles | Domain shift test |
+
+## Script
+
+```bash
+# scripts/benchmark.sh
+python -m src.training.evaluate \
+  --model models/teacher-qwen-rababa/ \
+  --test-data data/processed/test.jsonl \
+  --report docs/benchmark-report-teacher.md
+
+python -m src.training.evaluate \
+  --model models/student-rababa/student.onnx \
+  --test-data data/processed/test.jsonl \
+  --report docs/benchmark-report-student.md
+
+# Compare all models side-by-side
+python -m src.training.evaluate \
+  --compare models/legacy-tacotron models/teacher-qwen models/student \
+  --test-data data/processed/test.jsonl \
+  --report docs/benchmark-comparison.md
+```
+
+## Acceptance
+
+- [ ] DER metric implemented and unit-tested
+- [ ] All 4 model variants evaluated on all 4 datasets
+- [ ] Comparison report generated as markdown
+- [ ] Student DER < 4% on Tashkeela++ test split
+- [ ] Student browser latency < 30ms/word
+- [ ] Student ONNX < 10 MB

--- a/TODO.rababa/06-huggingface-publishing.md
+++ b/TODO.rababa/06-huggingface-publishing.md
@@ -1,0 +1,114 @@
+# rababa-v2: 06 — HuggingFace publishing + model card
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Goal
+
+Publish trained models to HuggingFace Hub with proper model cards so
+the community can verify provenance, evaluate independently, and
+reproduce.
+
+## Repositories
+
+```
+huggingface.co/interscript/rababa-teacher-qwen    # 2-4B teacher
+huggingface.co/interscript/rababa-student-v2       # 5-10M distilled student
+huggingface.co/interscript/rababa-legacy-tacotron  # 60MB legacy (for parity)
+```
+
+## Model card template (docs/model_card.md)
+
+```markdown
+---
+license: mit
+language:
+  - ar
+tags:
+  - arabic
+  - diacritization
+  - harakat
+  - onnx
+  - interscript
+base_model: Qwen/Qwen2.5-3B
+pipeline_tag: text2text-generation
+---
+
+# Rababa v2 — Arabic Diacritization (Student)
+
+## Description
+Distilled student model for Arabic diacritization. Adds harakat
+(vowel marks) to undiacritized Arabic text.
+
+## Architecture
+4-layer character-level transformer, distilled from a Qwen2.5-3B
+teacher fine-tuned on Tashkeela++.
+
+## Inputs / Outputs
+- Input: undiacritized Arabic text (UTF-8 bytes)
+- Output: diacritized Arabic text with haraqat
+
+## Performance
+| Metric | Value |
+|---|---|
+| DER | 3.2% |
+| WER | 8.1% |
+| Size | 6.4 MB |
+| Latency (Node) | 5ms/word |
+| Latency (WASM SIMD) | 22ms/word |
+
+## Training data
+- Tashkeela++ (50M words, gold labels)
+- Synthetic augmentation from teacher (100M words, silver labels)
+
+## Limitations
+- Max input length: 200 characters
+- Trained on MSA (Modern Standard Arabic); dialect performance varies
+- No transliteration — use with interscript for that
+
+## Citation
+```
+@misc{interscript-rababa-v2,
+  title={Rababa v2: Modern Arabic Diacritization},
+  author={Interscript Contributors},
+  year={2026},
+  url={https://github.com/interscript/rababa-v2}
+}
+```
+
+## License
+MIT (code) + CC-BY-4.0 (model weights)
+```
+
+## Publishing script
+
+```bash
+# scripts/publish.sh
+huggingface-cli login --token $HF_TOKEN
+
+# Upload student model
+huggingface-cli upload interscript/rababa-student-v2 \
+  models/student-rababa/student.onnx \
+  --commit-message "v2.0 student model (DER 3.2%)"
+
+huggingface-cli upload interscript/rababa-student-v2 \
+  docs/model_card.md \
+  --commit-message "model card"
+```
+
+## interscript-ts integration
+
+After publishing:
+```typescript
+setModelBase("https://huggingface.co/interscript/interscript-models/resolve/main")
+// rababa/200/model.onnx → legacy Tacotron
+// rababa/200/student-v2.onnx → new student
+```
+
+## Acceptance
+
+- [ ] HuggingFace org `interscript` created
+- [ ] All 3 model repos published with model cards
+- [ ] Direct download URLs work from interscript-ts
+- [ ] Model card includes DER, WER, size, latency
+- [ ] Citation block + license documented

--- a/TODO.rababa/07-hebrew-diacritization.md
+++ b/TODO.rababa/07-hebrew-diacritization.md
@@ -1,0 +1,42 @@
+# rababa-v2: 07 — Hebrew diacritization (same pipeline, different data)
+
+**Status:** SPECIFICATION
+**Priority:** P2
+
+## Goal
+
+Apply the same training pipeline to Hebrew diacritization. Hebrew
+faces the same problem as Arabic: text is normally written without
+vowel marks (nikud). The rababa Ruby gem already has a Hebrew path
+(`python/hebrew/`), but it uses the same legacy Tacotron architecture.
+
+## Training data
+
+- **Hebrew Wiktionary**: nikud-annotated entries
+- **Sefaria**: open Torah/Tanakh texts with full nikud
+- **Hebrew National Corpus**: modern Hebrew with nikud
+- Total: ~10-20M words (smaller than Arabic; may need more synthetic
+  augmentation)
+
+## Architecture
+
+Same student architecture as Arabic (00-05). Different training data.
+The fine-tuned teacher handles Hebrew + Arabic in one model if the
+base LLM supports both (Qwen2.5 and Gemma-2 both do).
+
+## Map integration
+
+```ruby
+# var-heb-Hebr-Hebr-rababa.imp (new map)
+stage {
+  rababa config: "hebrew", model: "llm"
+}
+```
+
+## Acceptance
+
+- [ ] Hebrew training data pipeline built
+- [ ] Student model trained on Hebrew
+- [ ] DER < 5% on Hebrew test split (higher tolerance than Arabic
+  because of smaller training corpus)
+- [ ] ONNX exported and loadable in interscript-ts

--- a/TODO.rababa/08-secryst-thai-ipa.md
+++ b/TODO.rababa/08-secryst-thai-ipa.md
@@ -1,0 +1,78 @@
+# rababa-v2: 08 — Secryst modernization (same pipeline for Thai→IPA)
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Goal
+
+Apply the same modernize-then-distill approach to Secryst, starting
+with the Thai → IPA transliteration task.
+
+## Why
+
+Secryst's vanilla transformer has no pretraining. A fine-tuned LLM
+leverages multilingual understanding of Thai characters, tone rules,
+and phonological patterns that the from-scratch transformer must learn
+from scratch.
+
+## Data
+
+- **Wiktionary Thai-IPA pairs**: ~10K parallel entries (already used
+  by the Ruby secryst map)
+- **Synthetic**: use existing rule-based Thai transliteration maps to
+  generate "noisy" pairs, then have the teacher correct them
+- **Tone-marked text corpora**: Thai text with explicit tone annotation
+  from linguistic resources
+
+## Pipeline (reuses rababa-v2 infrastructure)
+
+```
+rababa-v2/                ← Arabic diacritization
+secryst-v2/               ← Thai → IPA (NEW — same structure)
+├── src/
+│   ├── data/
+│   │   ├── download_wiktionary.py
+│   │   ├── clean_thai.py
+│   │   └── augment_thai.py
+│   ├── models/
+│   │   ├── teacher_llm.py      # same LLM fine-tune, different prompt
+│   │   └── student.py          # same architecture
+│   ├── training/
+│   │   ├── finetune.py
+│   │   ├── distill.py
+│   │   └── evaluate.py         # phoneme error rate instead of DER
+│   └── export/
+│       └── onnx_export.py
+├── configs/
+│   ├── teacher_thai.yaml
+│   └── student_thai.yaml
+└── docs/
+    └── model_card.md
+```
+
+## Teacher fine-tune prompt
+
+```
+Transliterate the following Thai text to IPA (International Phonetic Alphabet):
+คฺวาม-วาว
+---
+kʰwaːm˧.waːw˧
+```
+
+The LLM learns to produce IPA from Thai characters. Its multilingual
+pretraining already includes IPA notation (from Wikipedia phonetic
+transcriptions).
+
+## Evaluation
+
+- **Phoneme Error Rate (PER)**: fraction of IPA symbols predicted wrong
+- **Tone accuracy**: fraction of tone marks (˧˦˥˩) predicted correctly
+- These are more relevant than DER for cross-script transliteration
+
+## Acceptance
+
+- [ ] Thai-IPA training data pipeline built
+- [ ] Teacher fine-tuned with PER < 15%
+- [ ] Student distilled and exported to ONNX (<10 MB)
+- [ ] All 11 test vectors from var-tha-Thai-Zsym-ipa.imp pass
+- [ ] Published to HuggingFace with model card

--- a/TODO.rababa/09-cicd.md
+++ b/TODO.rababa/09-cicd.md
@@ -1,0 +1,47 @@
+# rababa-v2: 09 — CI/CD for the training pipeline
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Goal
+
+Reproducible training runs with CI verification. Every model change
+goes through automated quality gates before publishing.
+
+## GitHub Actions workflows
+
+### .github/workflows/test.yml (CPU, every PR)
+- Lint (ruff)
+- Unit tests (pytest)
+- Data pipeline integrity checks
+- Model forward-pass smoke test (random weights)
+
+### .github/workflows/train.yml (GPU, manual trigger)
+- Triggers on: workflow_dispatch (manual), new tag `model-v*`
+- Spins up a GPU runner (self-hosted or Lambda Labs)
+- Runs full training pipeline: data → fine-tune → distill → evaluate → export
+- Uploads model artifact to GitHub Releases
+- Uploads to HuggingFace Hub
+- Opens a PR to interscript-ts updating the model URL in the manifest
+
+### .github/workflows/benchmark.yml (CPU, weekly)
+- Downloads the latest published model
+- Runs DER benchmark on Tashkeela++ test split
+- Compares with previous week's result
+- Alerts if DER regressed > 0.5%
+
+## Model versioning
+
+Semantic versioning for model weights:
+- `rababa-student-v2.0.0` — initial release
+- `rababa-student-v2.1.0` — retrained with more data (DER improved)
+- `rababa-student-v2.0.1` — same weights, ONNX export fix
+
+Version stored in the model manifest (consumed by interscript-ts).
+
+## Acceptance
+
+- [ ] test.yml runs on every PR
+- [ ] train.yml produces a model artifact
+- [ ] benchmark.yml runs weekly with regression detection
+- [ ] Model versioning documented

--- a/TODO.rababa/10-unified-framework.md
+++ b/TODO.rababa/10-unified-framework.md
@@ -1,0 +1,99 @@
+# rababa-v2: 10 — Unified ML training framework (shared with secryst)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+One training framework for ALL ML-powered interscript models. Rababa
+(Arabic/Hebrew diacritization) and Secryst (Thai→IPA transliteration)
+share the same pipeline. Each task is a **config + dataset**, not a
+separate codebase.
+
+## Unified repo: `interscript/ml-models`
+
+```
+interscript/ml-models/
+├── src/
+│   ├── framework/             # SHARED — both rababa and secryst use this
+│   │   ├── __init__.py
+│   │   ├── config.py          # TaskConfig dataclass (loaded from YAML)
+│   │   ├── pipeline.py        # TrainingPipeline orchestrator
+│   │   ├── data.py            # DataModule base class (OCP: new sources = subclass)
+│   │   ├── model.py           # ModelModule base class (OCP: new arch = subclass)
+│   │   ├── trainer.py         # BaseTrainer (DRY: shared epoch loop)
+│   │   ├── evaluator.py       # BaseEvaluator (DER, PER, WER metrics)
+│   │   └── exporter.py        # ONNX export + verification
+│   │
+│   ├── tasks/                 # TASK-SPECIFIC — one directory per task
+│   │   ├── rababa_arabic/     # Arabic diacritization
+│   │   │   ├── config.yaml
+│   │   │   ├── data.py        # RababaArabicData(DataModule)
+│   │   │   ├── prompts.py     # Instruction format for LLM teacher
+│   │   │   └── metrics.py     # DER implementation
+│   │   ├── rababa_hebrew/     # Hebrew diacritization
+│   │   │   ├── config.yaml
+│   │   │   └── data.py
+│   │   └── secryst_thai_ipa/  # Thai → IPA transliteration
+│   │       ├── config.yaml
+│   │       ├── data.py
+│   │       └── metrics.py     # PER implementation
+│   │
+│   └── cli.py                 # `python -m src.cli train --task rababa_arabic`
+│
+├── models/                    # Output directory (gitignored, git-LFS)
+├── configs/                   # Shared default configs
+├── scripts/                   # setup, train, publish
+├── tests/                     # Framework + task tests
+└── docs/
+```
+
+## Key abstractions (OCP/MECE/DRY)
+
+```python
+# src/framework/data.py — MECE: data source knows nothing about model
+class DataModule(ABC):
+    @abstractmethod
+    def prepare_data(self) -> None: ...
+    @abstractmethod
+    def train_dataloader(self) -> DataLoader: ...
+    @abstractmethod
+    def val_dataloader(self) -> DataLoader: ...
+
+# src/framework/model.py — MECE: model knows nothing about data source
+class ModelModule(ABC):
+    @abstractmethod
+    def forward(self, batch) -> Loss: ...
+    @abstractmethod
+    def generate(self, input_ids) -> output_ids: ...
+
+# src/framework/trainer.py — DRY: shared training loop
+class BaseTrainer:
+    def fit(self, model: ModelModule, data: DataModule): ...
+    def distill(self, teacher: ModelModule, student: ModelModule, data: DataModule): ...
+
+# src/framework/evaluator.py — OCP: new metric = new subclass
+class BaseEvaluator(ABC):
+    @abstractmethod
+    def evaluate(self, predictions, gold) -> dict: ...
+
+class DEREvaluator(BaseEvaluator): ...  # rababa
+class PEREvaluator(BaseEvaluator): ...  # secryst
+```
+
+## Adding a new task
+
+1. Create `src/tasks/<name>/config.yaml`
+2. Create `src/tasks/<name>/data.py` extending `DataModule`
+3. (Optional) Create `src/tasks/<name>/metrics.py` extending `BaseEvaluator`
+4. Run: `python -m src.cli train --task <name>`
+
+Zero edits to framework code. **OCP**.
+
+## Acceptance
+
+- [ ] Framework modules implement all abstractions
+- [ ] rababa_arabic task configured and runnable
+- [ ] rababa_hebrew task configured
+- [ ] secryst_thai_ipa task configured
+- [ ] Tests cover framework + each task

--- a/TODO.rababa/11-ruby-autoload-integration.md
+++ b/TODO.rababa/11-ruby-autoload-integration.md
@@ -1,0 +1,84 @@
+# rababa-v2: 11 — Ruby autoload integration (code quality mandate)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+Ensure the Ruby side (interscript-ruby) follows strict autoload
+conventions for the rababa/secryst ML function integration. No
+`require_relative`, no `require` for internal library code.
+
+## Rules (from project conventions)
+
+1. **Never use `require_relative` for internal library code.** Use
+   Ruby `autoload` instead.
+2. **Never use `require` with a path to code within the library.**
+   Use `autoload`.
+3. **Define autoload entries in the immediate parent namespace's file.**
+   Create the file if it doesn't exist.
+4. **Never use `send` to call private methods.** Redesign if needed.
+5. **Never use `instance_variable_set` or `instance_variable_get`.**
+   Add public accessors.
+6. **Never use `respond_to?` for type checking.** Use `is_a?` or
+   design the type hierarchy so checks aren't needed.
+
+## Current violations in interscript-ruby
+
+```ruby
+# lib/interscript/stdlib.rb — VIOLATION: require_relative
+require "interscript"  # this is OK (external)
+# But internal requires like these should be autoloads:
+require_relative "something"  # VIOLATION
+```
+
+Check and fix:
+```bash
+grep -rn "require_relative" lib/interscript/  # find violations
+grep -rn "require \"" lib/interscript/ | grep -v "^[^:]*:require \"[a-z]"  # internal requires
+```
+
+## Fix pattern
+
+```ruby
+# lib/interscript.rb (parent namespace file)
+module Interscript
+  # autoload every child constant here
+  autoload :Stdlib,        "interscript/stdlib"
+  autoload :Compiler,      "interscript/compiler"
+  autoload :Interpreter,   "interscript/interpreter"
+  autoload :Detector,      "interscript/detector"
+  # ... etc
+end
+
+# lib/interscript/stdlib.rb
+class Interscript::Stdlib
+  # Don't require children — autoload them
+  autoload :Functions, "interscript/stdlib/functions"
+  # ...
+end
+```
+
+## For ML integration specifically
+
+When rababa/secryst functions are added to the Ruby stdlib:
+
+```ruby
+# lib/interscript/stdlib.rb — parent file
+class Interscript::Stdlib
+  module Functions
+    autoload :RababaAdapter, "interscript/stdlib/functions/rababa_adapter"
+    autoload :SecrystAdapter, "interscript/stdlib/functions/secryst_adapter"
+  end
+end
+```
+
+**No `require_relative` anywhere in the library.**
+
+## Acceptance
+
+- [ ] Zero `require_relative` calls in `lib/interscript/`
+- [ ] Zero internal `require` calls (only autoload)
+- [ ] Every namespace has autoload entries in its parent file
+- [ ] Parent files created where they don't exist
+- [ ] Specs pass with autoload (lazy loading works)

--- a/TODO.rababa/12-browser-optimization.md
+++ b/TODO.rababa/12-browser-optimization.md
@@ -1,0 +1,63 @@
+# rababa-v2: 12 — Browser inference optimization
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Goal
+
+Make ML inference fast enough in the browser that it's indistinguishable
+from rule-based transliteration.
+
+## Stack
+
+```
+User types Arabic text
+  → Web Worker (off main thread)
+    → onnxruntime-web
+      → WebGPU (if available) or WASM SIMD (fallback)
+        → Student model (~6 MB, cached via Service Worker)
+          → Diacritized output
+```
+
+## Optimization layers
+
+### 1. WebGPU execution provider (5-10× over WASM)
+```typescript
+const session = await ort.InferenceSession.create(modelData, {
+  executionProviders: ["webgpu", "wasm"],
+})
+```
+Auto-detected. Chrome/Edge/Safari 17+ support WebGPU. Falls back
+seamlessly.
+
+### 2. WASM SIMD + multi-threading
+```typescript
+ort.env.wasm.simd = true
+ort.env.wasm.numThreads = navigator.hardwareConcurrency || 4
+```
+Default for browsers without WebGPU (Firefox). SIMD gives ~2× over
+scalar WASM.
+
+### 3. Model caching
+- First visit: download 6 MB ONNX via fetch()
+- Service Worker caches the file permanently
+- IndexedDB for the ORT session itself (avoids re-creating)
+- Subsequent visits: instant load from cache
+
+### 4. Speculative decoding (advanced)
+For the student model: predict 2 tokens at a time, verify the second
+token with the teacher. If correct, skip ahead. ~1.5× speedup on
+long inputs.
+
+### 5. Quantization-free small model
+The student is already 6 MB — no quantization needed. The whole point
+of distillation is to get the right size WITHOUT compression that
+degrades quality.
+
+## Acceptance
+
+- [ ] WebGPU path implemented with fallback
+- [ ] Service Worker caches ONNX model
+- [ ] Inference: <20ms/word (WebGPU), <50ms/word (WASM SIMD)
+- [ ] No UI freeze during inference (Web Worker)
+- [ ] First-load progress indicator

--- a/TODO.rababa/13-unified-model-interface.md
+++ b/TODO.rababa/13-unified-model-interface.md
@@ -1,0 +1,89 @@
+# rababa-v2: 13 — Unified model interface for interscript-ts
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Goal
+
+One TypeScript interface for ALL ML models. The runtime doesn't know
+or care whether a model is rababa, secryst, ByT5, or a distilled student.
+It calls `model.transform(input)` and gets output back.
+
+## Current state
+
+```
+RababaModel.diacritize(text) → string
+SecrystModel.translate(text) → string
+```
+
+Two different method names for the same concept. Should be unified.
+
+## Unified interface
+
+```typescript
+// src/ml/types.ts
+export interface MLModel extends Model {
+  /** Transform input text → output text. The universal method. */
+  transform(input: string): Promise<string>
+}
+```
+
+Both RababaModel and SecrystModel implement `transform`:
+
+```typescript
+// Rababa
+class RababaModelImpl implements MLModel {
+  async transform(input: string): Promise<string> {
+    return this.diacritize(input)  // delegates to existing method
+  }
+}
+
+// Secryst
+class SecrystModelImpl implements MLModel {
+  async transform(input: string): Promise<string> {
+    // Process line by line, matching Ruby behavior
+    const lines = input.split("\n")
+    const results: string[] = []
+    for (const line of lines) {
+      results.push(await this.translate(line))
+    }
+    return results.join("\n")
+  }
+}
+```
+
+## Interpreter integration
+
+The async funcall handler doesn't need to know which model it's calling:
+
+```typescript
+// src/runtime/interpreter.ts
+async function executeFuncallAsync(rule, ctx) {
+  if (ASYNC_FUNCTIONS.has(rule.name)) {
+    const { loadModel } = await import("../ml/index.js")
+    const model = await loadModel({
+      kind: rule.name,  // "rababa" or "secryst"
+      id: rule.kwargs?.config ?? rule.kwargs?.model ?? "default",
+    }) as MLModel
+    ctx.current = await model.transform(ctx.current)
+    return
+  }
+  // ... sync fallback
+}
+```
+
+**OCP**: adding a new ML function = registering it in `ASYNC_FUNCTIONS`
++ having its model implement `MLModel.transform`. The interpreter
+never changes.
+
+**MECE**: the interpreter knows about `ASYNC_FUNCTIONS` and `MLModel.transform`.
+It does NOT know about Arabic diacritization, Thai transliteration, or
+any model-specific details.
+
+## Acceptance
+
+- [ ] `MLModel.transform(input)` defined in types
+- [ ] RababaModel implements transform (delegates to diacritize)
+- [ ] SecrystModel implements transform (line-by-line translate)
+- [ ] Interpreter uses unified interface (no per-model branching)
+- [ ] Specs verify both models satisfy MLModel

--- a/TODO.rababa/14-production-deployment.md
+++ b/TODO.rababa/14-production-deployment.md
@@ -1,0 +1,61 @@
+# rababa-v2: 14 — Production deployment + monitoring
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Goal
+
+ML models running reliably in production: API endpoint serves ML maps,
+monitoring catches regressions, CI prevents bad models from deploying.
+
+## API integration
+
+The existing `/api/transliterate` endpoint already supports async:
+```typescript
+export const prerender = false
+// POST /api/transliterate uses transliterateAsync internally
+```
+
+When a user calls `/api/transliterate?system=var-ara-Arab-Arab-rababa`:
+1. Server loads the rababa student model (cached after first call)
+2. Runs inference via `onnxruntime-node`
+3. Returns diacritized output
+
+Model is loaded once per server process (singleton). Cached in memory.
+
+## Cold start
+
+First request after server start: ~2-5 seconds (model load + ONNX session init).
+Subsequent requests: ~50-200ms per word.
+
+Mitigation:
+- Warm-up request on server start (loads model immediately)
+- Health check endpoint reports model status
+
+## Monitoring
+
+### Model health
+- Track DER on a fixed held-out set every hour
+- Alert if DER > 5% (student regressed or model file corrupted)
+
+### Latency
+- p50, p95, p99 inference time per request
+- Alert if p95 > 500ms
+
+### Error rate
+- Percentage of requests returning SystemConversionError
+- Alert if > 1% in a 5-minute window
+
+## CDN strategy
+
+Static site + maps: Cloudflare/Vercel CDN (already configured).
+ML models: HuggingFace CDN (already configured in provisioner).
+ONNX runtime: bundled via npm (onnxruntime-node for server, onnxruntime-web for browser).
+
+## Acceptance
+
+- [ ] API endpoint serves ML maps without timeout
+- [ ] Warm-up on server start
+- [ ] Health check reports ML model status
+- [ ] DER monitoring with alerting
+- [ ] Latency dashboard on /status page

--- a/TODO.rababa/README.md
+++ b/TODO.rababa/README.md
@@ -1,0 +1,103 @@
+# ML Modernization Plan — Unified Schedule
+
+**Goal:** One interface (`transliterateAsync`) for every Interscript map,
+including ML-powered ones (rababa, secryst). Train modern LLM-based
+models to replace the legacy Tacotron/vanilla-transformer.
+
+## Architecture decision
+
+Replace Tacotron CBHG (a speech model repurposed for text) with:
+1. **Teacher**: Qwen3.5-4B fine-tuned via LoRA on task-specific data
+2. **Student**: 6M-param character-level transformer distilled from teacher
+
+The student ships in the browser (~6 MB ONNX, <30ms/word).
+
+## Unified repository
+
+One repo trains ALL models: `interscript/ml-models`
+
+```
+src/tasks/
+├── rababa_arabic/      # Arabic diacritization (replaces Tacotron)
+├── rababa_hebrew/      # Hebrew diacritization (nikud)
+├── secryst_thai_ipa/   # Thai → IPA (replaces vanilla transformer)
+└── [future tasks]      # Khmer, Japanese, Chinese...
+```
+
+Each task = one config + one data module. Shared framework. OCP.
+
+## Prioritized schedule
+
+| Phase | Items | Status | Est. |
+|---|---|---|---|
+| **P0: Foundation** | | | |
+| Async executor | #85 | ✅ DONE | |
+| ML abstraction layer | #61 | ✅ DONE | |
+| Rababa port (TS side) | #60 | ✅ DONE | |
+| Secryst port (TS side) | #87 | ✅ DONE | |
+| Unified transliterateAsync | #86 | ✅ DONE | |
+| Unified MLModel interface | #13 | SPEC | 0.5 day |
+| **P0: Training** | | | |
+| Unified training repo | #10 | SPEC | 1 day |
+| Data pipeline (Arabic) | rababa/01 | SPEC | 2 days |
+| Teacher fine-tune (Arabic) | rababa/02 | SPEC | 1 day (GPU) |
+| Student distillation | rababa/03 | SPEC | 2 days (GPU) |
+| ONNX export | rababa/04 | SPEC | 0.5 day |
+| Evaluation suite | rababa/05 | SPEC | 1 day |
+| Thai→IPA data + training | secryst/01-05 | SPEC | 1 week |
+| **P1: Deploy** | | | |
+| HuggingFace hosting | rababa/06 | SPEC | 1 day |
+| Website /ml page | #95 | SPEC | 1 day |
+| API endpoint for ML maps | #14 | SPEC | 0.5 day |
+| Browser optimization | rababa/12 | SPEC | 1 day |
+| **P1: Ruby integration** | | | |
+| Ruby autoload compliance | rababa/11 | SPEC | 1 day |
+| Ruby ML adapters | secryst/09 | SPEC | 1 day |
+| **P2: Scale** | | | |
+| Hebrew diacritization | rababa/07 | SPEC | 1 week |
+| Future tasks (Khmer, JP, ZH) | secryst/07 | SPEC | TBD |
+| CI/CD for training | rababa/09 | SPEC | 1 day |
+
+## Key design decisions
+
+1. **No quantization.** Train a better model instead. Quantizing a
+   bad architecture (Tacotron) makes it smaller but not better.
+2. **LLM teacher + distilled student.** Qwen3.5-4B has Arabic/Thai
+   understanding from pretraining. Distill to 6 MB for browser.
+3. **Unified framework.** Rababa and Secryst share everything except
+   data and config. Adding a new task takes 5 minutes.
+4. **OCP throughout.** New model kinds, new tasks, new backends =
+   one new file each. Existing code never changes.
+5. **Ruby autoload.** No `require_relative`. No `send`. No
+   `instance_variable_set`. No `respond_to?`. Clean OOP.
+
+## File index
+
+### TODO.rababa/
+- 00: Repository specification
+- 01: Data pipeline (Tashkeela++)
+- 02: Teacher model (Qwen3.5-4B)
+- 03: Student model (distillation)
+- 04: ONNX export + integration
+- 05: Evaluation + benchmark
+- 06: HuggingFace publishing
+- 07: Hebrew diacritization
+- 08: Secryst Thai→IPA (cross-ref to TODO.secryst/)
+- 09: CI/CD
+- 10: Unified training framework
+- 11: Ruby autoload compliance
+- 12: Browser inference optimization
+- 13: Unified model interface (MLModel.transform)
+- 14: Production deployment + monitoring
+
+### TODO.secryst/
+- 00: Repository specification (unified with rababa)
+- 01: Thai→IPA data pipeline
+- 02: Teacher model (Qwen3.5-4B for Thai)
+- 03: Student model (shared architecture)
+- 04: ONNX export + integration
+- 05: Evaluation (PER instead of DER)
+- 06: HuggingFace publishing
+- 07: Future transliteration tasks
+- 08: CI/CD (shared)
+- 09: Ruby autoload compliance

--- a/TODO.rababa/README.md
+++ b/TODO.rababa/README.md
@@ -4,13 +4,42 @@
 including ML-powered ones (rababa, secryst). Train modern LLM-based
 models to replace the legacy Tacotron/vanilla-transformer.
 
+## Where the code lives
+
+**Implementation:** https://github.com/interscript/ml-models
+
+This monorepo (`TODO.rababa/`, `TODO.secryst/`) holds the **specs and
+schedule**. The framework + task packages live in the separate
+`interscript/ml-models` repo (sibling layout under
+`/Users/mulgogi/src/interscript/ml-models/`). Distribution plan is in
+`TODO.distribution/` in that repo.
+
 ## Architecture decision
 
-Replace Tacotron CBHG (a speech model repurposed for text) with:
-1. **Teacher**: Qwen3.5-4B fine-tuned via LoRA on task-specific data
-2. **Student**: 6M-param character-level transformer distilled from teacher
+**Direct supervised training of a ~30M param character-level transformer
+on the gold corpus.** No LLM teacher.
 
-The student ships in the browser (~6 MB ONNX, <30ms/word).
+For diacritization, the corpus is authoritative. Tashkeela++ is
+~2M verses of scholar-annotated Arabic with full harakat. An LLM
+teacher fine-tuned on the same corpus can't add information the
+corpus doesn't already have — it only adds noise + cost.
+
+Two tiers:
+- **Tier 1 (default)**: ~30M char transformer, self-pretrained on
+  unlabeled Arabic then fine-tuned on Tashkeela++. ~$10-15/task.
+  DER 4-6%. Browser at q8 (~8MB).
+- **Tier 2 (optional quality)**: distill from a fine-tuned ByT5-base
+  teacher (also trained on Tashkeela++) into the same 30M student.
+  ~$25-35/task. DER 3-4%.
+
+The teacher in Tier 2 is *also* a student of Tashkeela++, not an LLM
+with prior opinions. Distillation here is a *compression* strategy,
+not a *labeling* strategy.
+
+See `ml-models/docs/architecture.md` for the full ADR.
+
+A CPU-only `StudentTrainer` exists for dev / CI / mobile variants —
+it trains the student directly on gold labels on a laptop.
 
 ## Unified repository
 
@@ -38,10 +67,10 @@ Each task = one config + one data module. Shared framework. OCP.
 | Unified transliterateAsync | #86 | ✅ DONE | |
 | Unified MLModel interface | #13 | SPEC | 0.5 day |
 | **P0: Training** | | | |
-| Unified training repo | #10 | SPEC | 1 day |
+| Unified training repo | #10 | ✅ DONE | 1 day |
 | Data pipeline (Arabic) | rababa/01 | SPEC | 2 days |
-| Teacher fine-tune (Arabic) | rababa/02 | SPEC | 1 day (GPU) |
-| Student distillation | rababa/03 | SPEC | 2 days (GPU) |
+| Self-pretrain (Arabic) | rababa/02b | SPEC | 0.5 day (GPU) |
+| Direct supervised fine-tune | rababa/03 | SPEC | 1 day (GPU) |
 | ONNX export | rababa/04 | SPEC | 0.5 day |
 | Evaluation suite | rababa/05 | SPEC | 1 day |
 | Thai→IPA data + training | secryst/01-05 | SPEC | 1 week |

--- a/TODO.secryst/00-repository-specification.md
+++ b/TODO.secryst/00-repository-specification.md
@@ -1,0 +1,51 @@
+# secryst-v2: 00 — Repository specification (unified with rababa-v2)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Unified repo
+
+Secryst and Rababa share one training repo: `interscript/ml-models`.
+
+See `TODO.rababa/10-unified-framework.md` for the full structure. This
+file documents the secryst-specific aspects.
+
+## Secryst task definitions
+
+Each secryst task lives in `src/tasks/secryst_<source>_<target>/`:
+
+```
+src/tasks/
+├── secryst_thai_ipa/          # Thai → IPA (the active map)
+│   ├── config.yaml            # task-specific hyperparams
+│   ├── data.py                # ThaiIPAData(DataModule)
+│   ├── prompts.py             # LLM instruction format
+│   └── metrics.py             # PEREvaluator(BaseEvaluator)
+├── secryst_khmer_ipa/         # Khmer → IPA (future)
+│   └── ...
+├── secryst_amharic_latin/     # Amharic → Latin (future)
+│   └── ...
+```
+
+## Shared framework (see TODO.rababa/10)
+
+Both rababa and secryst use:
+- `src/framework/data.py` — DataModule base
+- `src/framework/model.py` — ModelModule base (teacher + student)
+- `src/framework/trainer.py` — BaseTrainer (fine-tune + distill)
+- `src/framework/exporter.py` — ONNX export
+- `src/framework/evaluator.py` — BaseEvaluator
+
+## What differs per task
+
+| Aspect | Rababa (diacritization) | Secryst (transliteration) |
+|---|---|---|
+| Input script | Arabic/Hebrew | Thai/Khmer/etc. |
+| Output script | Same + haraqat | IPA/Latin |
+| Metric | DER | PER (phoneme error rate) |
+| Teacher prompt | "Add harakat" | "Transliterate to IPA" |
+| Training data | Tashkeela++ | Wiktionary pairs |
+| Map integration | `rababa config: "200"` | `secryst model: "thai-ipa"` |
+
+The differences are **config + data only**. The training pipeline is
+identical. This is the core of the unification.

--- a/TODO.secryst/01-data-pipeline.md
+++ b/TODO.secryst/01-data-pipeline.md
@@ -1,0 +1,50 @@
+# secryst-v2: 01 — Thai → IPA data pipeline
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Sources
+
+### Primary: Wiktionary Thai-IPA extraction
+- Parse Wiktionary entries that have both Thai script and IPA
+- ~10K-15K parallel pairs (enough for fine-tuning with pre-trained LLM)
+- Source: https://en.wiktionary.org/wiki/Category:Thai_terms_with_IPA_pronunciation
+- Scraper: `src/tasks/secryst_thai_ipa/data.py:download_wiktionary()`
+
+### Secondary: existing test vectors
+- The 11 test vectors in `var-tha-Thai-Zsym-ipa.imp` serve as held-out test
+- Never used in training — pure evaluation
+
+### Synthetic augmentation
+- Take undiacritized Thai text from Thai Wikipedia / OSCAR
+- Run existing rule-based Thai maps to get approximate transliterations
+- Use the teacher model to "correct" these — creates silver-label pairs
+- Mix gold (Wiktionary) + silver 50/50
+
+## Data format
+
+```jsonl
+{"input": "คฺวาม-วาว", "output": "kʰwaːm˧.waːw˧"}
+{"input": "ที่-เปิด-ขวด", "output": "tʰiː˥˩.pɤːt̚˨˩.kʰua̯t̚˨˩"}
+```
+
+Character-level input (Thai chars), character-level output (IPA chars).
+No special tokenization — ByT5/Qwen handles raw bytes.
+
+## Pipeline (reuses framework)
+
+```
+DataModule.prepare_data()
+  → download wiktionary dump
+  → parse entries with Thai + IPA
+  → clean: remove entries with missing IPA, normalize Unicode
+  → split: 90% train / 5% val / 5% test
+  → augment with synthetic data
+```
+
+## Acceptance
+
+- [ ] Wiktionary scraper produces ≥10K clean parallel pairs
+- [ ] All 11 map test vectors excluded from training data
+- [ | Synthetic augmentation pipeline works
+- [ ] Data integrity tests pass

--- a/TODO.secryst/02-teacher-model.md
+++ b/TODO.secryst/02-teacher-model.md
@@ -1,0 +1,58 @@
+# secryst-v2: 02 — Teacher model (Qwen3.5-4B for Thai→IPA)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Approach
+
+Same as rababa (see `TODO.rababa/02-teacher-model.md`) but with
+Thai-specific prompts. The Qwen3.5-4B model already understands Thai
+characters and IPA notation from pretraining.
+
+## Fine-tune prompt
+
+```
+<|im_start|>system
+Transliterate the following Thai text to IPA (International Phonetic
+Alphabet) notation. Use tone marks (˧ ˦ ˥ ˩ ˨) where appropriate.<|im_end|>
+<|im_start|>user
+คฺวาม-วาว<|im_end|>
+<|im_start|>assistant
+kʰwaːm˧.waːw˧<|im_end|>
+```
+
+## Config
+
+```yaml
+# configs/teacher_qwen35_thai.yaml
+model: Qwen/Qwen3.5-4B
+method: lora
+lora:
+  r: 16
+  alpha: 32
+  target_modules: [q_proj, v_proj, k_proj, o_proj, gate_proj, up_proj, down_proj]
+training:
+  epochs: 5         # more epochs — less data than rababa
+  batch_size: 8
+  gradient_accumulation: 4
+  learning_rate: 3e-4  # slightly higher — smaller dataset
+  bf16: true
+data:
+  train_split: data/processed/thai_ipa_train.jsonl
+  val_split: data/processed/thai_ipa_val.jsonl
+output: models/teacher-qwen35-thai-ipa/
+```
+
+## Why Qwen3.5-4B works for Thai
+
+- Qwen models are developed by Alibaba — strong Asian language support
+- Thai is well-represented in Qwen pretraining data
+- IPA notation appears in Wikipedia phonetic transcriptions (pretraining)
+- The 4B model has enough capacity to learn tone rules from ~10K examples
+
+## Acceptance
+
+- [ ] Fine-tuning runs on single A100
+- [ ] PER < 15% on held-out Wiktionary test split
+- [ ] All 11 map test vectors pass (exact match)
+- [ ] Model checkpoint saved

--- a/TODO.secryst/03-student-model.md
+++ b/TODO.secryst/03-student-model.md
@@ -1,0 +1,65 @@
+# secryst-v2: 03 — Student model (shared architecture with rababa)
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Architecture
+
+Identical to `TODO.rababa/03-student-model.md`. The same 6M-param
+character-level transformer:
+
+```python
+StudentDiacritizer(  # rename to StudentTransformer
+  vocab_size=256,    # UTF-8 byte-level — covers both Thai AND IPA
+  d_model=256, nhead=4, num_layers=4, dim_ff=1024, max_len=256,
+)
+```
+
+The student is script-agnostic. It maps input bytes → output bytes.
+Whether those bytes encode Arabic+haraqat or Thai+IPA is irrelevant
+to the architecture — only the training data differs.
+
+## Distillation
+
+Same process as rababa:
+1. Teacher (Qwen3.5-4B fine-tuned on Thai→IPA) generates labels
+2. Student trains on teacher's output distribution (KL divergence)
+3. Export to ONNX (~6 MB)
+
+## Config
+
+```yaml
+# configs/student_thai_ipa.yaml
+architecture:
+  vocab_size: 256
+  d_model: 256
+  nhead: 4
+  num_layers: 4
+  dim_feedforward: 1024
+  max_len: 256
+training:
+  epochs: 100
+  batch_size: 64
+  learning_rate: 3e-4
+  teacher_temperature: 2.0
+output: models/student-thai-ipa/
+```
+
+## Evaluation
+
+Phoneme Error Rate (PER) instead of DER:
+```python
+def per(predicted_ipa: str, gold_ipa: str) -> float:
+    """Phoneme Error Rate: edit distance over IPA symbols."""
+    pred_symbols = parse_ipa(predicted_ipa)  # split into phoneme units
+    gold_symbols = parse_ipa(gold_ipa)
+    return levenshtein(pred_symbols, gold_symbols) / len(gold_symbols)
+```
+
+## Acceptance
+
+- [ ] Same student architecture as rababa (DRY — one class)
+- [ ] Distilled model achieves PER < 20%
+- [ ] All 11 map test vectors pass
+- [ ] ONNX < 10 MB
+- [ ] Browser inference < 30ms/word

--- a/TODO.secryst/04-onnx-export-integration.md
+++ b/TODO.secryst/04-onnx-export-integration.md
@@ -1,0 +1,44 @@
+# secryst-v2: 04 — ONNX export + interscript-ts integration
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Same export pipeline as rababa (TODO.rababa/04)
+
+The student model exports identically. The ONNX input/output names
+match the Secryst translator interface already implemented in
+interscript-ts (`src/ml/models/secryst/translator.ts`).
+
+## interscript-ts integration
+
+The SecrystModel already exists in `src/ml/models/secryst/`:
+- `vocab.ts` — token vocabulary
+- `masks.ts` — attention mask construction
+- `translator.ts` — autoregressive decode loop
+- `index.ts` — registered as "secryst" in the ML registry
+
+To use the new distilled student:
+1. Export the student ONNX with matching input names (src, tgt, masks)
+2. Bundle the vocab (byte-level: 256 tokens, no YAML needed)
+3. Publish to HuggingFace
+4. Update the provisioner manifest
+
+## Map integration
+
+```ruby
+# var-tha-Thai-Zsym-ipa.imp (existing map, no change needed)
+stage {
+  secryst model: "thai-ipa"
+  # ... post-processing sub rules ...
+}
+```
+
+The runtime loads the model via `loadModel({kind: "secryst", id: "thai-ipa"})`,
+runs autoregressive decode, and passes the output to subsequent rules.
+
+## Acceptance
+
+- [ ] Student ONNX exported with correct input/output names
+- [ ] Loads in interscript-ts via existing SecrystModel code
+- [ ] All 11 test vectors pass
+- [ ] Published to HuggingFace as `interscript/secryst-thai-ipa`

--- a/TODO.secryst/05-evaluation-benchmark.md
+++ b/TODO.secryst/05-evaluation-benchmark.md
@@ -1,0 +1,48 @@
+# secryst-v2: 05 — Evaluation + benchmark
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Same framework as rababa (TODO.rababa/05), different metrics
+
+| Metric | Rababa | Secryst |
+|---|---|---|
+| Primary | DER (haraqat error rate) | PER (phoneme error rate) |
+| Secondary | WER (word error rate) | CER (character error rate) |
+| Integration | 3 test vectors in .imp | 11 test vectors in .imp |
+
+## PER implementation
+
+```python
+# src/tasks/secryst_thai_ipa/metrics.py
+from src.framework.evaluator import BaseEvaluator
+
+class PEREvaluator(BaseEvaluator):
+    """Phoneme Error Rate over IPA symbols."""
+
+    def evaluate(self, predictions: list[str], gold: list[str]) -> dict:
+        total_errors = 0
+        total_symbols = 0
+        for pred, true in zip(predictions, gold):
+            pred_phonemes = self._parse_ipa(pred)
+            true_phonemes = self._parse_ipa(true)
+            dist = levenshtein(pred_phonemes, true_phonemes)
+            total_errors += dist
+            total_symbols += len(true_phonemes)
+        per = total_errors / max(total_symbols, 1)
+        return {"PER": per, "total_symbols": total_symbols}
+```
+
+## Tone accuracy (Thai-specific)
+
+Tone marks (˧ ˦ ˥ ˩ ˨) are the hardest part of Thai→IPA. Track them
+separately:
+- What % of tone marks are predicted correctly?
+- Which tones are most often confused?
+
+## Acceptance
+
+- [ ] PER evaluator implemented and tested
+- [ ] Tone accuracy metric implemented
+- [ ] Student PER < 20% on test split
+- [ ] Comparison report: legacy vs teacher vs student

--- a/TODO.secryst/06-huggingface-publishing.md
+++ b/TODO.secryst/06-huggingface-publishing.md
@@ -1,0 +1,59 @@
+# secryst-v2: 06 — HuggingFace publishing + model card
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Same as rababa (TODO.rababa/06), different repo
+
+```
+huggingface.co/interscript/secryst-thai-ipa-teacher    # Qwen3.5-4B teacher
+huggingface.co/interscript/secryst-thai-ipa-student    # 6M distilled student
+```
+
+## Model card
+
+```markdown
+---
+license: mit
+language:
+  - th
+tags:
+  - thai
+  - transliteration
+  - ipa
+  - onnx
+  - interscript
+base_model: Qwen/Qwen3.5-4B
+pipeline_tag: text2text-generation
+---
+
+# Secryst v2 — Thai → IPA Transliteration (Student)
+
+## Description
+Distilled student model for phonemic Thai → IPA transliteration.
+Predicts International Phonetic Alphabet notation including tone marks.
+
+## Performance
+| Metric | Value |
+|---|---|
+| PER | 18.3% |
+| Tone accuracy | 82.1% |
+| Size | 6.2 MB |
+| Latency (Node) | 8ms/word |
+| Latency (WASM) | 25ms/word |
+
+## Training data
+- Wiktionary Thai-IPA pairs (~12K, gold)
+- Synthetic augmentation from teacher (100K, silver)
+
+## Limitations
+- Max input length: 200 characters
+- Trained on Wiktionary; domain-specific Thai may differ
+- Tone prediction is the main error source
+```
+
+## Acceptance
+
+- [ ] Both repos published with model cards
+- [ ] Direct download URLs work from interscript-ts
+- [ ] Model card includes PER, tone accuracy, size, latency

--- a/TODO.secryst/07-future-tasks.md
+++ b/TODO.secryst/07-future-tasks.md
@@ -1,0 +1,72 @@
+# secryst-v2: 07 — Future transliteration tasks (unified pipeline)
+
+**Status:** SPECIFICATION
+**Priority:** P2
+
+## Goal
+
+The unified framework (TODO.rababa/10) makes adding new secryst tasks
+trivial: one config + one data module per task. This file documents
+candidates.
+
+## Candidate tasks
+
+### Khmer → IPA
+- Parallel data: Khmer diacritics repo (`interscript/khmer-diacritics`)
+- Already has a secryst model in Ruby (Khmer script)
+- Would benefit from LLM pretraining (Khmer is in Qwen's training data)
+
+### Amharic → Latin (morphological)
+- Some Amharic transliteration decisions depend on morphology
+  (verb root vs. noun form) — rules can't always disambiguate
+- Training data: parallel Amharic-English dictionaries + ALA-LC tables
+- Currently handled by rules; ML could improve accuracy on edge cases
+
+### Japanese → Romaji (context-dependent)
+- Multiple readings for the same kanji (人 = jin, nin, hito, ...)
+- Context determines the reading — a task LLMs excel at
+- Training data: furigana-annotated corpora (BCCWJ, Aozora Bunko)
+- Would be a new map: `var-jpn-Hrkt-Latn-llm`
+
+### Chinese → Pinyin (context-dependent polyphones)
+- Some characters have multiple readings (了 = le, liǎo)
+- Context determines pronunciation
+- LLMs already solve this in production (translation APIs)
+- Would replace/augment the existing Hanyu Pinyin maps
+
+## How to add a new task (5 minutes)
+
+```bash
+# 1. Create the task directory
+mkdir -p src/tasks/secryst_<source>_<target>/
+
+# 2. Write the config
+cat > src/tasks/secryst_<source>_<target>/config.yaml << EOF
+model: Qwen/Qwen3.5-4B
+method: lora
+data:
+  train_split: data/processed/<source>_<target>_train.jsonl
+  val_split: data/processed/<source>_<target>_val.jsonl
+EOF
+
+# 3. Write the data module
+cat > src/tasks/secryst_<source>_<target>/data.py << EOF
+from src.framework.data import DataModule
+
+class MyData(DataModule):
+    def prepare_data(self):
+        # Download + clean + augment
+        ...
+EOF
+
+# 4. Train
+python -m src.cli train --task secryst_<source>_<target>
+```
+
+Zero edits to framework code. **OCP**.
+
+## Acceptance
+
+- [ ] At least one additional task (Khmer→IPA or Japanese→Romaji) configured
+- [ ] Task runs through the unified pipeline
+- [ ] Documentation shows the 5-minute process

--- a/TODO.secryst/08-cicd.md
+++ b/TODO.secryst/08-cicd.md
@@ -1,0 +1,41 @@
+# secryst-v2: 08 — CI/CD (shared with rababa-v2)
+
+**Status:** SPECIFICATION
+**Priority:** P1
+
+## Same CI/CD as rababa (TODO.rababa/09)
+
+The unified repo `interscript/ml-models` has one CI pipeline. Each task
+is a matrix entry:
+
+```yaml
+# .github/workflows/train.yml
+jobs:
+  train:
+    strategy:
+      matrix:
+        task:
+          - rababa_arabic
+          - rababa_hebrew
+          - secryst_thai_ipa
+    steps:
+      - run: python -m src.cli train --task ${{ matrix.task }}
+```
+
+## Per-task quality gates
+
+Each task has its own DER/PER threshold in the config:
+```yaml
+# configs/secryst_thai_ipa.yaml
+evaluation:
+  metric: PER
+  max_threshold: 0.20  # fail if PER > 20%
+```
+
+CI fails if any task exceeds its threshold.
+
+## Acceptance
+
+- [ ] All tasks run via the same workflow
+- [ ] Per-task quality gates enforced
+- [ ] Model artifacts uploaded to HuggingFace on success

--- a/TODO.secryst/09-ruby-autoload-compliance.md
+++ b/TODO.secryst/09-ruby-autoload-compliance.md
@@ -1,0 +1,64 @@
+# secryst-v2: 09 — Ruby autoload compliance
+
+**Status:** SPECIFICATION
+**Priority:** P0
+
+## Same rules as rababa (TODO.rababa/11)
+
+The Ruby side (`interscript-ruby/lib/interscript/stdlib.rb`) must use
+`autoload` for all internal library code. No `require_relative`.
+
+## Current secryst integration
+
+```ruby
+# lib/interscript/stdlib.rb — current
+def self.secryst(output, model:)
+  begin
+    require "secryst"  # OK: external gem
+  rescue
+    nil
+  end
+  ...
+end
+```
+
+The `require "secryst"` is for the external gem — that's fine. But
+if we add adapter modules for the new ML pipeline:
+
+```ruby
+# CORRECT — autoload in parent file
+# lib/interscript/stdlib.rb
+class Interscript::Stdlib
+  module Functions
+    autoload :RababaAdapter, "interscript/stdlib/functions/rababa_adapter"
+    autoload :SecrystAdapter, "interscript/stdlib/functions/secryst_adapter"
+  end
+end
+
+# lib/interscript/stdlib/functions/secryst_adapter.rb
+class Interscript::Stdlib::Functions::SecrystAdapter
+  def self.call(output, model:)
+    # ... delegate to the external secryst gem or new ML pipeline
+  end
+end
+```
+
+**No `require_relative` anywhere in `lib/interscript/`.**
+
+## Parent namespace files
+
+Ensure these exist and have autoload entries:
+- `lib/interscript/stdlib.rb` → autoloads `Functions`
+- `lib/interscript/stdlib/functions.rb` → autoloads each adapter
+  (create this file if it doesn't exist)
+- `lib/interscript/stdlib/functions/rababa_adapter.rb` → implementation
+- `lib/interscript/stdlib/functions/secryst_adapter.rb` → implementation
+
+## Acceptance
+
+- [ ] Zero `require_relative` in `lib/interscript/`
+- [ ] Zero internal `require` calls (external gems are OK)
+- [ ] Parent namespace files exist with autoload entries
+- [ ] Specs pass with lazy autoload
+- [ ] No `send` to private methods, no `instance_variable_set/get`,
+      no `respond_to?` for type checking


### PR DESCRIPTION
## Summary
- Revises `TODO.rababa/README.md` to match the architecture decision in `ml-models/docs/architecture.md`.
- Drops the LLM-teacher framing (Qwen3.5-4B + LoRA) as the default path. For diacritization, the gold corpus is authoritative — an LLM teacher fine-tuned on the same corpus can only add noise + cost, not information.
- New framing: Tier 1 direct supervised (~30M char transformer on Tashkeela++, DER 4-6%, browser at q8 ~8MB); Tier 2 optional distillation from a fine-tuned ByT5-base teacher (also trained on gold — compression, not labeling).
- Adds a "Where the code lives" section pointing at `interscript/ml-models`.

## Context
This is the spec/schedule monorepo. Implementation lives in the sibling `ml-models` repo. The README here tracks the plan + design rationale; the architecture ADR itself is at `ml-models/docs/architecture.md`.

## Test plan
- [x] Doc-only change
